### PR TITLE
Update README.md, add .gitattributes, convert Mac files.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+*.txt		text
+*.[chsi]	text
+*.asm		text
+*.md		text
+GNUmakefile*	text
+
+*.a		-text

--- a/README.md
+++ b/README.md
@@ -1,9 +1,55 @@
-# 3DO M1 Opera Portfolio OS
+# 3DO Opera Portfolio OS
 
-The 3DO M1 Opera platform ran an OS called Portfolio. For the time a quite advanced operating system which supported preemptive multitasking, dynamic code loading, supervisor/user process separation, memory fences (MMU), threading, message passing, a filesystem, high level IO abstractions, device drivers, etc. Portfolio was created to ease development on the platform but it also acted as an abstraction to the hardware so that manufacturers had more flexibility in their design and provide for compatibility with future systems (which were designed but never released to retail.)
+The 3DO Opera platform ran an OS called Portfolio.  Developed internally at
+NTG/3DO by several of the same people who developed the operating system for
+the Amiga computer, Portfolio takes many of its design cues from Amiga.
+Indeed, Amiga programmers will find Portfolio quite familiar.  However,
+Portfolio addresses many of the shortcomings levelled against Amiga, making
+it quite advanced for the early 1990's, particularly when compared to
+mystifyingly more popular operating systems such as MS-DOS.
 
-On 2022-01-07 a snapshot of the M1 Opera's Portfolio OS from 1995-02-10 was uploaded to Archive.org by user [EagleSoft](https://archive.org/details/@eaglesoft).
+Among other features, Portfolio provides:
+
+  - Preemptive threading/multitasking,
+  - User/supervisor separation
+  - Memory protection (MMU/fences) and process separation,
+  - Resource tracking -- memory and I/O resources are released when a
+    process dies,
+  - Asynchronous, high-level I/O system,
+  - Shared libraries,
+  - Dynamically loaded libraries and device drivers,
+  - Message-based IPC,
+  - Custom filesystem,
+  - Extensible global error codes,
+  - Input handling for joypads, joysticks, mice, and light gun.
+
+Portfolio was created to ease development on the platform, but it also acted
+as an abstraction to the hardware so that manufacturers had more flexibility
+in their design and provide for compatibility with future systems (which
+were designed but never released to retail).
+
+On 2022-01-07 a snapshot of the Opera's Portfolio OS from 1995-02-10 was
+uploaded to Archive.org by user
+[EagleSoft](https://archive.org/details/@eaglesoft).
+
 
 ## What is This Repo?
 
-This repo is a copy of the Portfolio OS source code which was released by EagleSoft on 2022-01-07. While I wasn't responsible for the release of the Portfolio source code I was in contact with the individual who did so prior to release, run the site [3DO Development Repo](https://3dodev.com), and am the primary maintainer of the libretro 3DO emulator [Opera](https://docs.libretro.com/library/opera). This repo is in the least a GitHub hosted backup and reference but may be a starting place for future development.
+This repo is a copy of the Portfolio OS source code which was released by
+EagleSoft on 2022-01-07.  While I wasn't responsible for the release of the
+Portfolio source code, I was in contact with the individual who did so prior
+to release.  I also run the site [3DO Development Repo](https://3dodev.com),
+and am the primary maintainer of the libretro 3DO emulator
+[Opera](https://docs.libretro.com/library/opera).  This repo is, at the very
+least, a GitHub hosted backup and reference, but may be a starting place for
+future development.
+
+The initial checkin represents a snapshot of the Opera source tree from
+around 1995.  Code revision was managed internally at NTG using
+[RCS](https://en.wikipedia.org/wiki/Revision_Control_System), but the RCS
+history is not present here.
+
+Portfolio is *vaguely* portable, as it was successfully ported to IBM's POWER
+architecture ([PowerPC
+602](https://en.wikipedia.org/wiki/PowerPC_600#PowerPC_602)) as part of the
+development for M2.  However, that port does not appear here.

--- a/release/examples/Audio/Audio.make
+++ b/release/examples/Audio/Audio.make
@@ -1,1 +1,164 @@
-###################################################################################  Copyright (C) 1995, an unpublished work by The 3DO Company. All rights reserved.##  This material contains confidential information that is the property of The 3DO Company.##  Any unauthorized duplication, disclosure or use is prohibited.###################################################################################   File:       Audio.make#   Target:     Examples:Audio folder#   Created:    Friday, November 18, 1994 4:19:14 PM##	Description:	Makes the contents of the Audio folder and all its subdirectories.##		Change History (most recent first):##		01.27.95	Modified to support MPW's pre-3.4 skanky Make utility. jwb#   	12.09.94	Initial implementation.	jwb######################################	Symbol definitions#####################################App				= AudioDebugFlag		= 1ObjectDir		= :ObjectsTempDir			= :MainDir					 = :Advanced_Sound_PlayerDir = :Advanced_Sound_PlayerCoal_RiverDir			 = :Coal_RiverDrumBoxDir				 = :DrumBoxJugglerDir				 = :JugglerCC				= armccLINK			= armlink######################################	Default compiler options#####################################COptions			= -fa -zps0 -za1CDebugOptions		= -g -d DEBUG={DebugFlag}LOptions			= -aif -r -b 0x00 -workspace 0x10000LStackSize			= 6000LDebugOptions		= -dModbinDebugOptions	= -debug######################################	Object files#####################################OBJECTS			=	 {ObjectDir}:beep.c.o ¶					 {ObjectDir}:capture_audio.c.o ¶					 {ObjectDir}:minmax_audio.c.o ¶					 {ObjectDir}:playmf.c.o ¶					 {ObjectDir}:playsample.c.o ¶					 {ObjectDir}:playsoundfile.c.o ¶					 {ObjectDir}:simple_envelope.c.o ¶					 {ObjectDir}:spoolsoundfile.c.o ¶					 {ObjectDir}:ta_attach.c.o ¶					 {ObjectDir}:ta_customdelay.c.o ¶					 {ObjectDir}:ta_envelope.c.o ¶					 {ObjectDir}:ta_pitchnotes.c.o ¶					 {ObjectDir}:ta_spool.c.o ¶					 {ObjectDir}:ta_sweeps.c.o ¶					 {ObjectDir}:ta_timer.c.o ¶					 {ObjectDir}:ta_tuning.c.o ¶					 {ObjectDir}:ta_tweakknobs.c.o ¶					 {ObjectDir}:tsc_soundfx.c.o ¶# OBJECTS			=	 {ObjectDir}:beep.c.o 					 ADVANCED_SOUND_PLAYER_OBJECTS	=	¶					{Advanced_Sound_PlayerDir}{ObjectDir}:tsp_algorithmic.c.o ¶					{Advanced_Sound_PlayerDir}{ObjectDir}:tsp_rooms.c.o ¶					{Advanced_Sound_PlayerDir}{ObjectDir}:tsp_spoolsoundfile.c.o ¶					{Advanced_Sound_PlayerDir}{ObjectDir}:tsp_switcher.c.o ¶										COAL_RIVER_OBJECTS	=	¶					{Coal_RiverDir}{ObjectDir}:CoalRiver.c.o					DRUMBOX_OBJECTS		= 	¶					{DrumBoxDir}{ObjectDir}:drumbox.c.o					JUGGLER_OBJECTS		= 	¶					{JugglerDir}{ObjectDir}:tj_canon.c.o ¶					{JugglerDir}{ObjectDir}:tj_multi.c.o ¶					{JugglerDir}{ObjectDir}:tj_simple.c.o					LIBS			=	"{3DOLibs}lib3DO.lib"		¶					"{3DOLibs}graphics.lib"		¶					"{3DOLibs}music.lib"		¶					"{3DOLibs}audio.lib"		¶					"{3DOLibs}operamath.lib"	¶					"{3DOLibs}filesystem.lib"		¶					"{3DOLibs}input.lib"		¶					"{3DOLibs}clib.lib"		¶					"{3DOLibs}swi.lib"		¶					"{3DOLibs}cstartup.o" #					"{3DOLibs}copyright.o" ¶#					"{3DOLibs}exampleslib.lib" ¶#					"{3DOLibs}compression.lib" ¶#					"{3DOLibs}memdebug.lib" ¶									######################################	Default build rules#####################################All				Ä	{App}.c.o	Ä	.c			{CC} -i "{3DOIncludes}" {COptions} {CDebugOptions} -o {TargDir}{Default}.c.o {DepDir}{Default}.c	set AudioLinkOK 1	# The ExecutableDir business here gets around an MPW 3.3 and earlier make bug	set ExecutableDir "{DepDir}Apps_Data"	if {ExecutableDir} == "Apps_Data"		set ExecutableDir ":Apps_Data"	end	{LINK} {LOptions} {LDebugOptions} ¶		{TargDir}{Default}.c.o ¶		{LIBS} ¶		-o {Default}.nostrip || (delete {TargDir}{Default}.c.o; set AudioLinkOK 0)	if {AudioLinkOK} == 1		SetFile {TempDir}{Default}.nostrip -c 'EaDJ' -t PROJ		modbin {TempDir}{Default}.nostrip -stack {LStackSize} {ModbinDebugOptions}			if "`Exists {ExecutableDir}:{Default}`"			delete {ExecutableDir}:{Default}		end			if "`Exists {TargDir}{Default}.sym`"			delete {TargDir}{Default}.sym		end			stripaif {TempDir}{Default}.nostrip -o {ExecutableDir}:{Default} -s {TargDir}{Default}.sym		delete {TempDir}{Default}.nostrip	end############################################ Directory and subdirectory dependencies###########################################{ObjectDir}:									Ä	{MainDir}{Advanced_Sound_PlayerDir}{ObjectDir}:			Ä	{Advanced_Sound_PlayerDir}:{Coal_RiverDir}{ObjectDir}:						Ä	{Coal_RiverDir}:{DrumBoxDir}{ObjectDir}:						Ä	{DrumBoxDir}:{JugglerDir}{ObjectDir}:						Ä	{JugglerDir}:{App} Ä {App}.make {OBJECTS} ¶			{ADVANCED_SOUND_PLAYER_OBJECTS} ¶			{COAL_RIVER_OBJECTS} ¶			{DRUMBOX_OBJECTS} ¶			{JUGGLER_OBJECTS} 	echo 'Make of audio examples completed.'	beep 2C,15 1G,5 1Gb,5 1G,5 1Ab,15 1G,30 1B,15 2C,15 
+
+###############################################################################
+##
+##  Copyright (C) 1995, an unpublished work by The 3DO Company. All rights reserved.
+##  This material contains confidential information that is the property of The 3DO Company.
+##  Any unauthorized duplication, disclosure or use is prohibited.
+##
+###############################################################################
+#
+#   File:       Audio.make
+#   Target:     Examples:Audio folder
+#   Created:    Friday, November 18, 1994 4:19:14 PM
+#
+#	Description:	Makes the contents of the Audio folder and all its subdirectories.
+#
+#		Change History (most recent first):
+#
+#		01.27.95	Modified to support MPW's pre-3.4 skanky Make utility. jwb
+#   	12.09.94	Initial implementation.	jwb
+
+#####################################
+#	Symbol definitions
+#####################################
+
+App				= Audio
+DebugFlag		= 1
+
+ObjectDir		= :Objects
+TempDir			= :
+
+MainDir					 = :
+Advanced_Sound_PlayerDir = :Advanced_Sound_Player
+Coal_RiverDir			 = :Coal_River
+DrumBoxDir				 = :DrumBox
+JugglerDir				 = :Juggler
+
+CC				= armcc
+LINK			= armlink
+
+#####################################
+#	Default compiler options
+#####################################
+
+COptions			= -fa -zps0 -za1
+CDebugOptions		= -g -d DEBUG={DebugFlag}
+LOptions			= -aif -r -b 0x00 -workspace 0x10000
+LStackSize			= 6000
+LDebugOptions		= -d
+ModbinDebugOptions	= -debug
+
+#####################################
+#	Object files
+#####################################
+
+OBJECTS			=	 {ObjectDir}:beep.c.o âˆ‚
+					 {ObjectDir}:capture_audio.c.o âˆ‚
+					 {ObjectDir}:minmax_audio.c.o âˆ‚
+					 {ObjectDir}:playmf.c.o âˆ‚
+					 {ObjectDir}:playsample.c.o âˆ‚
+					 {ObjectDir}:playsoundfile.c.o âˆ‚
+					 {ObjectDir}:simple_envelope.c.o âˆ‚
+					 {ObjectDir}:spoolsoundfile.c.o âˆ‚
+					 {ObjectDir}:ta_attach.c.o âˆ‚
+					 {ObjectDir}:ta_customdelay.c.o âˆ‚
+					 {ObjectDir}:ta_envelope.c.o âˆ‚
+					 {ObjectDir}:ta_pitchnotes.c.o âˆ‚
+					 {ObjectDir}:ta_spool.c.o âˆ‚
+					 {ObjectDir}:ta_sweeps.c.o âˆ‚
+					 {ObjectDir}:ta_timer.c.o âˆ‚
+					 {ObjectDir}:ta_tuning.c.o âˆ‚
+					 {ObjectDir}:ta_tweakknobs.c.o âˆ‚
+					 {ObjectDir}:tsc_soundfx.c.o âˆ‚
+
+# OBJECTS			=	 {ObjectDir}:beep.c.o 	
+				 
+ADVANCED_SOUND_PLAYER_OBJECTS	=	âˆ‚
+					{Advanced_Sound_PlayerDir}{ObjectDir}:tsp_algorithmic.c.o âˆ‚
+					{Advanced_Sound_PlayerDir}{ObjectDir}:tsp_rooms.c.o âˆ‚
+					{Advanced_Sound_PlayerDir}{ObjectDir}:tsp_spoolsoundfile.c.o âˆ‚
+					{Advanced_Sound_PlayerDir}{ObjectDir}:tsp_switcher.c.o âˆ‚
+										
+COAL_RIVER_OBJECTS	=	âˆ‚
+					{Coal_RiverDir}{ObjectDir}:CoalRiver.c.o
+					
+
+DRUMBOX_OBJECTS		= 	âˆ‚
+					{DrumBoxDir}{ObjectDir}:drumbox.c.o
+					
+
+JUGGLER_OBJECTS		= 	âˆ‚
+					{JugglerDir}{ObjectDir}:tj_canon.c.o âˆ‚
+					{JugglerDir}{ObjectDir}:tj_multi.c.o âˆ‚
+					{JugglerDir}{ObjectDir}:tj_simple.c.o
+					
+LIBS			=	"{3DOLibs}lib3DO.lib"		âˆ‚
+					"{3DOLibs}graphics.lib"		âˆ‚
+					"{3DOLibs}music.lib"		âˆ‚
+					"{3DOLibs}audio.lib"		âˆ‚
+					"{3DOLibs}operamath.lib"	âˆ‚
+					"{3DOLibs}filesystem.lib"		âˆ‚
+					"{3DOLibs}input.lib"		âˆ‚
+					"{3DOLibs}clib.lib"		âˆ‚
+					"{3DOLibs}swi.lib"		âˆ‚
+					"{3DOLibs}cstartup.o" 
+#					"{3DOLibs}copyright.o" âˆ‚
+#					"{3DOLibs}exampleslib.lib" âˆ‚
+#					"{3DOLibs}compression.lib" âˆ‚
+#					"{3DOLibs}memdebug.lib" âˆ‚
+
+									
+
+#####################################
+#	Default build rules
+#####################################
+
+All				Æ’	{App}
+
+
+.c.o	Æ’	.c		
+	{CC} -i "{3DOIncludes}" {COptions} {CDebugOptions} -o {TargDir}{Default}.c.o {DepDir}{Default}.c
+	set AudioLinkOK 1
+	# The ExecutableDir business here gets around an MPW 3.3 and earlier make bug
+	set ExecutableDir "{DepDir}Apps_Data"
+	if {ExecutableDir} == "Apps_Data"
+		set ExecutableDir ":Apps_Data"
+	end
+	{LINK} {LOptions} {LDebugOptions} âˆ‚
+		{TargDir}{Default}.c.o âˆ‚
+		{LIBS} âˆ‚
+		-o {Default}.nostrip || (delete {TargDir}{Default}.c.o; set AudioLinkOK 0)
+	if {AudioLinkOK} == 1
+		SetFile {TempDir}{Default}.nostrip -c 'EaDJ' -t PROJ
+		modbin {TempDir}{Default}.nostrip -stack {LStackSize} {ModbinDebugOptions}	
+		if "`Exists {ExecutableDir}:{Default}`"
+			delete {ExecutableDir}:{Default}
+		end	
+		if "`Exists {TargDir}{Default}.sym`"
+			delete {TargDir}{Default}.sym
+		end	
+		stripaif {TempDir}{Default}.nostrip -o {ExecutableDir}:{Default} -s {TargDir}{Default}.sym
+		delete {TempDir}{Default}.nostrip
+	end
+
+###########################################
+# Directory and subdirectory dependencies
+###########################################
+
+{ObjectDir}:									Æ’	{MainDir}
+
+{Advanced_Sound_PlayerDir}{ObjectDir}:			Æ’	{Advanced_Sound_PlayerDir}:
+
+{Coal_RiverDir}{ObjectDir}:						Æ’	{Coal_RiverDir}:
+
+{DrumBoxDir}{ObjectDir}:						Æ’	{DrumBoxDir}:
+
+{JugglerDir}{ObjectDir}:						Æ’	{JugglerDir}:
+
+{App} Æ’ {App}.make {OBJECTS} âˆ‚
+			{ADVANCED_SOUND_PLAYER_OBJECTS} âˆ‚
+			{COAL_RIVER_OBJECTS} âˆ‚
+			{DRUMBOX_OBJECTS} âˆ‚
+			{JUGGLER_OBJECTS} 
+	echo 'Make of audio examples completed.'
+	beep 2C,15 1G,5 1Gb,5 1G,5 1Ab,15 1G,30 1B,15 2C,15 

--- a/release/examples/EventBroker/Control_Port_Peripherals/bs_example.make
+++ b/release/examples/EventBroker/Control_Port_Peripherals/bs_example.make
@@ -1,1 +1,97 @@
-######################################### Copyright (C) 1995, an unpublished work by The 3DO Company. All rights reserved.## This material contains confidential information that is the property of The 3DO Company.## Any unauthorized duplication, disclosure or use is prohibited.## $Id: bs_example.make,v 1.5 1995/01/19 01:24:29 mattm Exp $########################################   File:       bs_example.make#   Target:     bs_example#   Sources:    broker_shell.c bs_cpad.c bs_joystick.c bs_lgun.c bs_mouse.c main.c##   Copyright (c) 1995, The 3DO Company#   All rights reserved.#######################################	Symbol definitions#####################################App				= bs_exampleDebugFlag		= 1SourceDir		= {3DOFolder}Examples:EventBroker:Control_Port_Peripherals:ObjectDir		= :Objects:Apps_Data		= :Apps_Data:CC				= armccLINK			= armlinkWorkingDisk		=3DOAutodup		= -y######################################	Default compiler options#####################################COptions			= -fa -zps0 -za1CDebugOptions		= -g -d DEBUG={DebugFlag}LOptions			= -aif -r -b 0x00LStackSize			= 4096LDebugOptions		= -dModbinDebugOptions	= -debug######################################	Object files#####################################OBJECTS			=	 ¶					{ObjectDir}broker_shell.c.o ¶					{ObjectDir}bs_cpad.c.o ¶					{ObjectDir}bs_joystick.c.o ¶					{ObjectDir}bs_mouse.c.o ¶					{ObjectDir}bs_example.c.o ¶					"{3DOLibs}"cstartup.oLIBS			=	 ¶					"{3DOLibs}Lib3DO.lib" ¶					"{3DOLibs}filesystem.lib" ¶					"{3DOLibs}graphics.lib" ¶					"{3DOLibs}input.lib" ¶					"{3DOLibs}clib.lib" ¶######################################	Default build rules#####################################All				Ä	{App}{ObjectDir}		Ä	:.c.o	Ä	.c	{CC} -i "{3DOIncludes}" {COptions} {CDebugOptions} -o {TargDir}{Default}.c.o {DepDir}{Default}.c######################################	Target build rules#####################################{App} Ä {App}.make {OBJECTS}	{LINK} {LOptions} {LDebugOptions} ¶		{OBJECTS} ¶		{LIBS} ¶		-o "{WorkingDisk}"{Targ}	SetFile "{WorkingDisk}"{Targ} -c 'EaDJ' -t 'PROJ'	modbin "{WorkingDisk}"{Targ} -stack {LStackSize} {ModbinDebugOptions}	stripaif "{WorkingDisk}"{Targ} -o {Targ} -s {Targ}.sym	move {3DOAutodup} {Targ} "{Apps_Data}"	move {3DOAutodup} {Targ}.sym "{Apps_Data}"######################################	Additional Target Dependencies#####################################{ObjectDir}broker_shell.c.o		Ä	{App}.make{ObjectDir}bs_cpad.c.o			Ä	{App}.make{ObjectDir}bs_joystick.c.o		Ä	{App}.make{ObjectDir}bs_lgun.c.o			Ä	{App}.make{ObjectDir}bs_mouse.c.o			Ä	{App}.make{ObjectDir}bs_example.c.o		Ä	{App}.make
+#####################################
+##
+## Copyright (C) 1995, an unpublished work by The 3DO Company. All rights reserved.
+## This material contains confidential information that is the property of The 3DO Company.
+## Any unauthorized duplication, disclosure or use is prohibited.
+## $Id: bs_example.make,v 1.5 1995/01/19 01:24:29 mattm Exp $
+##
+#####################################
+#   File:       bs_example.make
+#   Target:     bs_example
+#   Sources:    broker_shell.c bs_cpad.c bs_joystick.c bs_lgun.c bs_mouse.c main.c
+#
+#   Copyright (c) 1995, The 3DO Company
+#   All rights reserved.
+#
+
+#####################################
+#	Symbol definitions
+#####################################
+
+App				= bs_example
+DebugFlag		= 1
+SourceDir		= {3DOFolder}Examples:EventBroker:Control_Port_Peripherals:
+ObjectDir		= :Objects:
+Apps_Data		= :Apps_Data:
+CC				= armcc
+LINK			= armlink
+WorkingDisk		=
+3DOAutodup		= -y
+
+#####################################
+#	Default compiler options
+#####################################
+
+COptions			= -fa -zps0 -za1
+CDebugOptions		= -g -d DEBUG={DebugFlag}
+LOptions			= -aif -r -b 0x00
+LStackSize			= 4096
+LDebugOptions		= -d
+ModbinDebugOptions	= -debug
+
+#####################################
+#	Object files
+#####################################
+
+OBJECTS			=	 âˆ‚
+					{ObjectDir}broker_shell.c.o âˆ‚
+					{ObjectDir}bs_cpad.c.o âˆ‚
+					{ObjectDir}bs_joystick.c.o âˆ‚
+					{ObjectDir}bs_mouse.c.o âˆ‚
+					{ObjectDir}bs_example.c.o âˆ‚
+					"{3DOLibs}"cstartup.o
+
+LIBS			=	 âˆ‚
+					"{3DOLibs}Lib3DO.lib" âˆ‚
+					"{3DOLibs}filesystem.lib" âˆ‚
+					"{3DOLibs}graphics.lib" âˆ‚
+					"{3DOLibs}input.lib" âˆ‚
+					"{3DOLibs}clib.lib" âˆ‚
+
+#####################################
+#	Default build rules
+#####################################
+
+All				Æ’	{App}
+
+{ObjectDir}		Æ’	:
+
+.c.o	Æ’	.c
+	{CC} -i "{3DOIncludes}" {COptions} {CDebugOptions} -o {TargDir}{Default}.c.o {DepDir}{Default}.c
+
+#####################################
+#	Target build rules
+#####################################
+
+{App} Æ’ {App}.make {OBJECTS}
+	{LINK} {LOptions} {LDebugOptions} âˆ‚
+		{OBJECTS} âˆ‚
+		{LIBS} âˆ‚
+		-o "{WorkingDisk}"{Targ}
+	SetFile "{WorkingDisk}"{Targ} -c 'EaDJ' -t 'PROJ'
+	modbin "{WorkingDisk}"{Targ} -stack {LStackSize} {ModbinDebugOptions}
+	stripaif "{WorkingDisk}"{Targ} -o {Targ} -s {Targ}.sym
+	move {3DOAutodup} {Targ} "{Apps_Data}"
+	move {3DOAutodup} {Targ}.sym "{Apps_Data}"
+
+#####################################
+#	Additional Target Dependencies
+#####################################
+
+{ObjectDir}broker_shell.c.o		Æ’	{App}.make
+{ObjectDir}bs_cpad.c.o			Æ’	{App}.make
+{ObjectDir}bs_joystick.c.o		Æ’	{App}.make
+{ObjectDir}bs_lgun.c.o			Æ’	{App}.make
+{ObjectDir}bs_mouse.c.o			Æ’	{App}.make
+{ObjectDir}bs_example.c.o		Æ’	{App}.make
+

--- a/release/examples/EventBroker/EventBroker_Tests/eventbroker_tests.make
+++ b/release/examples/EventBroker/EventBroker_Tests/eventbroker_tests.make
@@ -1,1 +1,83 @@
-######################################### Copyright (C) 1995, an unpublished work by The 3DO Company. All rights reserved.## This material contains confidential information that is the property of The 3DO Company.## Any unauthorized duplication, disclosure or use is prohibited.## $Id: eventbroker_tests.make,v 1.5 1995/01/19 01:40:18 mattm Exp $########################################   File:       EventBroker_Tests.make#   Target:     cpdump focus lookie luckie maus#   Sources:    cpdump.c focus.c lookie.c luckie.c maus.c##   Copyright (c) 1995, The 3DO Company#   All rights reserved.#######################################	Symbol definitions#####################################App				= EventBroker_TestsDebugFlag		= 1SourceDir		= {3DOFolder}Examples:EventBroker:EventBroker_Tests:ObjectDir		= :Objects:ExecutableDir	= {SourceDir}Apps_Data:TempDir			= :CC				= armccLINK			= armlink######################################	Default compiler options#####################################COptions			= -fa -zps0 -za1CDebugOptions		= -g -d DEBUG={DebugFlag}LOptions			= -aif -r -b 0x00 -workspace 0x10000LStackSize			= 6000LDebugOptions		= -dModbinDebugOptions	= -debug######################################	Object files#####################################OBJECTS			=	{ObjectDir}cpdump.c.o		¶					{ObjectDir}focus.c.o		¶					{ObjectDir}lookie.c.o		¶					{ObjectDir}luckie.c.o		¶					{ObjectDir}maus.c.o					LIBS			=	"{3DOLibs}Lib3DO.lib" ¶					"{3DOLibs}audio.lib" ¶					"{3DOLibs}music.lib" ¶					"{3DOLibs}operamath.lib" ¶					"{3DOLibs}filesystem.lib" ¶					"{3DOLibs}graphics.lib" ¶					"{3DOLibs}input.lib" ¶					"{3DOLibs}clib.lib"					######################################	Default build rules#####################################All				Ä	{App}{ObjectDir}		Ä	:.c.o	Ä	.c	{CC} -i "{3DOIncludes}" {COptions} {CDebugOptions} -o {TargDir}{Default}.c.o {DepDir}{Default}.c	{LINK} {LOptions} {LDebugOptions} ¶		{TargDir}{Default}.c.o ¶		"{3DOLibs}"cstartup.o ¶		{LIBS} ¶		-o {TempDir}{Default}.nostrip	SetFile {TempDir}{Default}.nostrip -c 'EaDJ' -t 'PROJ'	modbin {TempDir}{Default}.nostrip -stack {LStackSize} {ModbinDebugOptions}	stripaif {TempDir}{Default}.nostrip -o {ExecutableDir}{Default} -s {ExecutableDir}{Default}.sym	delete {TempDir}{Default}.nostrip{App} Ä {App}.make {OBJECTS}
+#####################################
+##
+## Copyright (C) 1995, an unpublished work by The 3DO Company. All rights reserved.
+## This material contains confidential information that is the property of The 3DO Company.
+## Any unauthorized duplication, disclosure or use is prohibited.
+## $Id: eventbroker_tests.make,v 1.5 1995/01/19 01:40:18 mattm Exp $
+##
+#####################################
+#   File:       EventBroker_Tests.make
+#   Target:     cpdump focus lookie luckie maus
+#   Sources:    cpdump.c focus.c lookie.c luckie.c maus.c
+#
+#   Copyright (c) 1995, The 3DO Company
+#   All rights reserved.
+#
+
+#####################################
+#	Symbol definitions
+#####################################
+
+App				= EventBroker_Tests
+DebugFlag		= 1
+
+SourceDir		= {3DOFolder}Examples:EventBroker:EventBroker_Tests:
+ObjectDir		= :Objects:
+ExecutableDir	= {SourceDir}Apps_Data:
+TempDir			= :
+
+CC				= armcc
+LINK			= armlink
+
+#####################################
+#	Default compiler options
+#####################################
+
+COptions			= -fa -zps0 -za1
+CDebugOptions		= -g -d DEBUG={DebugFlag}
+LOptions			= -aif -r -b 0x00 -workspace 0x10000
+LStackSize			= 6000
+LDebugOptions		= -d
+ModbinDebugOptions	= -debug
+
+#####################################
+#	Object files
+#####################################
+
+OBJECTS			=	{ObjectDir}cpdump.c.o		âˆ‚
+					{ObjectDir}focus.c.o		âˆ‚
+					{ObjectDir}lookie.c.o		âˆ‚
+					{ObjectDir}luckie.c.o		âˆ‚
+					{ObjectDir}maus.c.o
+					
+LIBS			=	"{3DOLibs}Lib3DO.lib" âˆ‚
+					"{3DOLibs}audio.lib" âˆ‚
+					"{3DOLibs}music.lib" âˆ‚
+					"{3DOLibs}operamath.lib" âˆ‚
+					"{3DOLibs}filesystem.lib" âˆ‚
+					"{3DOLibs}graphics.lib" âˆ‚
+					"{3DOLibs}input.lib" âˆ‚
+					"{3DOLibs}clib.lib"
+					
+#####################################
+#	Default build rules
+#####################################
+
+All				Æ’	{App}
+
+{ObjectDir}		Æ’	:
+
+.c.o	Æ’	.c
+	{CC} -i "{3DOIncludes}" {COptions} {CDebugOptions} -o {TargDir}{Default}.c.o {DepDir}{Default}.c
+	{LINK} {LOptions} {LDebugOptions} âˆ‚
+		{TargDir}{Default}.c.o âˆ‚
+		"{3DOLibs}"cstartup.o âˆ‚
+		{LIBS} âˆ‚
+		-o {TempDir}{Default}.nostrip
+	SetFile {TempDir}{Default}.nostrip -c 'EaDJ' -t 'PROJ'
+	modbin {TempDir}{Default}.nostrip -stack {LStackSize} {ModbinDebugOptions}
+	stripaif {TempDir}{Default}.nostrip -o {ExecutableDir}{Default} -s {ExecutableDir}{Default}.sym
+	delete {TempDir}{Default}.nostrip
+
+{App} Æ’ {App}.make {OBJECTS}
+

--- a/release/examples/EventBroker/Joystick/joystick_example.make
+++ b/release/examples/EventBroker/Joystick/joystick_example.make
@@ -1,1 +1,92 @@
-######################################### Copyright (C) 1995, an unpublished work by The 3DO Company. All rights reserved.## This material contains confidential information that is the property of The 3DO Company.## Any unauthorized duplication, disclosure or use is prohibited.## $Id: joystick_example.make,v 1.4 1995/01/19 01:25:37 mattm Exp $########################################   File:       joystick_example.make#   Target:     joystick_example#   Sources:    broker_shell.c bs_joystick.c joystick_example.c##   Copyright (c) 1995, The 3DO Company#   All rights reserved.#######################################	Symbol definitions#####################################App				= joystick_exampleDebugFlag		= 1SourceDir		= {3DOFolder}Examples:EventBroker:Joystick:ObjectDir		= :Objects:Apps_Data		= :Apps_Data:CC				= armccLINK			= armlinkWorkingDisk		=3DOAutodup		= -y######################################	Default compiler options#####################################COptions			= -fa -zps0 -za1CDebugOptions		= -g -d DEBUG={DebugFlag}LOptions			= -aif -r -b 0x00LStackSize			= 4096LDebugOptions		= -dModbinDebugOptions	= -debug######################################	Object files#####################################OBJECTS			=	 ¶					{ObjectDir}broker_shell.c.o ¶					{ObjectDir}bs_joystick.c.o ¶					{ObjectDir}joystick_example.c.o ¶					"{3DOLibs}"cstartup.oLIBS			=	 ¶					"{3DOLibs}Lib3DO.lib" ¶					"{3DOLibs}filesystem.lib" ¶					"{3DOLibs}graphics.lib" ¶					"{3DOLibs}input.lib" ¶					"{3DOLibs}clib.lib"######################################	Default build rules#####################################All				Ä	{App}{ObjectDir}		Ä	:.c.o	Ä	.c	{CC} -i "{3DOIncludes}" {COptions} {CDebugOptions} -o {TargDir}{Default}.c.o {DepDir}{Default}.c######################################	Target build rules#####################################{App} Ä {App}.make {OBJECTS}	{LINK} {LOptions} {LDebugOptions} ¶		{OBJECTS} ¶		{LIBS} ¶		-o "{WorkingDisk}"{Targ}	SetFile "{WorkingDisk}"{Targ} -c 'EaDJ' -t 'PROJ'	modbin "{WorkingDisk}"{Targ} -stack {LStackSize} {ModbinDebugOptions}	stripaif "{WorkingDisk}"{Targ} -o {Targ} -s {Targ}.sym	move {3DOAutodup} {Targ} "{Apps_Data}"	move {3DOAutodup} {Targ}.sym "{Apps_Data}"######################################	Additional Target Dependencies#####################################{ObjectDir}broker_shell.c.o			Ä	{App}.make{ObjectDir}bs_joystick.c.o			Ä	{App}.make{ObjectDir}joystick_example.c.o		Ä	{App}.make
+#####################################
+##
+## Copyright (C) 1995, an unpublished work by The 3DO Company. All rights reserved.
+## This material contains confidential information that is the property of The 3DO Company.
+## Any unauthorized duplication, disclosure or use is prohibited.
+## $Id: joystick_example.make,v 1.4 1995/01/19 01:25:37 mattm Exp $
+##
+#####################################
+#   File:       joystick_example.make
+#   Target:     joystick_example
+#   Sources:    broker_shell.c bs_joystick.c joystick_example.c
+#
+#   Copyright (c) 1995, The 3DO Company
+#   All rights reserved.
+#
+
+#####################################
+#	Symbol definitions
+#####################################
+
+App				= joystick_example
+DebugFlag		= 1
+SourceDir		= {3DOFolder}Examples:EventBroker:Joystick:
+ObjectDir		= :Objects:
+Apps_Data		= :Apps_Data:
+CC				= armcc
+LINK			= armlink
+WorkingDisk		=
+3DOAutodup		= -y
+
+#####################################
+#	Default compiler options
+#####################################
+
+COptions			= -fa -zps0 -za1
+CDebugOptions		= -g -d DEBUG={DebugFlag}
+LOptions			= -aif -r -b 0x00
+LStackSize			= 4096
+LDebugOptions		= -d
+ModbinDebugOptions	= -debug
+
+#####################################
+#	Object files
+#####################################
+
+OBJECTS			=	 âˆ‚
+					{ObjectDir}broker_shell.c.o âˆ‚
+					{ObjectDir}bs_joystick.c.o âˆ‚
+					{ObjectDir}joystick_example.c.o âˆ‚
+					"{3DOLibs}"cstartup.o
+
+LIBS			=	 âˆ‚
+					"{3DOLibs}Lib3DO.lib" âˆ‚
+					"{3DOLibs}filesystem.lib" âˆ‚
+					"{3DOLibs}graphics.lib" âˆ‚
+					"{3DOLibs}input.lib" âˆ‚
+					"{3DOLibs}clib.lib"
+
+#####################################
+#	Default build rules
+#####################################
+
+All				Æ’	{App}
+
+{ObjectDir}		Æ’	:
+
+.c.o	Æ’	.c
+	{CC} -i "{3DOIncludes}" {COptions} {CDebugOptions} -o {TargDir}{Default}.c.o {DepDir}{Default}.c
+
+#####################################
+#	Target build rules
+#####################################
+
+{App} Æ’ {App}.make {OBJECTS}
+	{LINK} {LOptions} {LDebugOptions} âˆ‚
+		{OBJECTS} âˆ‚
+		{LIBS} âˆ‚
+		-o "{WorkingDisk}"{Targ}
+	SetFile "{WorkingDisk}"{Targ} -c 'EaDJ' -t 'PROJ'
+	modbin "{WorkingDisk}"{Targ} -stack {LStackSize} {ModbinDebugOptions}
+	stripaif "{WorkingDisk}"{Targ} -o {Targ} -s {Targ}.sym
+	move {3DOAutodup} {Targ} "{Apps_Data}"
+	move {3DOAutodup} {Targ}.sym "{Apps_Data}"
+
+#####################################
+#	Additional Target Dependencies
+#####################################
+
+{ObjectDir}broker_shell.c.o			Æ’	{App}.make
+{ObjectDir}bs_joystick.c.o			Æ’	{App}.make
+{ObjectDir}joystick_example.c.o		Æ’	{App}.make
+

--- a/release/examples/EventBroker/LightGun/lightgundemo.make
+++ b/release/examples/EventBroker/LightGun/lightgundemo.make
@@ -1,1 +1,90 @@
-######################################### Copyright (C) 1995, an unpublished work by The 3DO Company. All rights reserved.## This material contains confidential information that is the property of The 3DO Company.## Any unauthorized duplication, disclosure or use is prohibited.## $Id: lightgundemo.make,v 1.3 1995/01/19 01:18:46 mattm Exp $########################################   File:       lightgundemo.make#   Target:     lightgundemo#   Sources:    lightgun.c lightgundemo.c##   Copyright 3DO Company, 1995#   All rights reserved.#######################################	Symbol definitions#####################################App				= lightgundemoDebugFlag		= 1SourceDir		= {3DOFolder}Examples:EventBroker:LightGun:ObjectDir		= :Objects:Apps_Data		= :Apps_Data:CC				= armccLINK			= armlinkWorkingDisk		=3DOAutoDup		= -y######################################	Default compiler options#####################################COptions			= -fa -zps0 -za1CDebugOptions		= -g -d DEBUG={DebugFlag}LOptions			= -aif -r -b 0x00LStackSize			= 4096LDebugOptions		= -dModbinDebugOptions	= -debug######################################	Object files#####################################OBJECTS			=	 {ObjectDir}lightgun.c.o {ObjectDir}lightgundemo.c.o "{3DOLibs}"cstartup.oLIBS			=	 ¶					"{3DOLibs}Lib3DO.lib" ¶					"{3DOLibs}audio.lib" ¶					"{3DOLibs}music.lib" ¶					"{3DOLibs}operamath.lib" ¶					"{3DOLibs}filesystem.lib" ¶					"{3DOLibs}graphics.lib" ¶					"{3DOLibs}input.lib" ¶					"{3DOLibs}clib.lib"######################################	Default build rules#####################################All				Ä	{App}{ObjectDir}		Ä	:.c.o	Ä	.c	{CC} -i "{3DOIncludes}" {COptions} {CDebugOptions} -o {TargDir}{Default}.c.o {DepDir}{Default}.c######################################	Target build rules#####################################{App} Ä {App}.make {OBJECTS}	{LINK} {LOptions} {LDebugOptions} ¶		{OBJECTS} ¶		{LIBS} ¶		-o "{WorkingDisk}"{Targ}	SetFile "{WorkingDisk}"{Targ} -c 'EaDJ' -t 'PROJ'	modbin "{WorkingDisk}"{Targ} -stack {LStackSize} {ModbinDebugOptions}	stripaif "{WorkingDisk}"{Targ} -o {Targ} -s {Targ}.sym	move {3DOAutodup} {Targ} "{Apps_Data}"	move {3DOAutodup} {Targ}.sym "{Apps_Data}"######################################	Additional Target Dependencies#####################################{ObjectDir}lightgun.c.o			Ä	{App}.make{ObjectDir}lightgundemo.c.o			Ä	{App}.make
+#####################################
+##
+## Copyright (C) 1995, an unpublished work by The 3DO Company. All rights reserved.
+## This material contains confidential information that is the property of The 3DO Company.
+## Any unauthorized duplication, disclosure or use is prohibited.
+## $Id: lightgundemo.make,v 1.3 1995/01/19 01:18:46 mattm Exp $
+##
+#####################################
+#   File:       lightgundemo.make
+#   Target:     lightgundemo
+#   Sources:    lightgun.c lightgundemo.c
+#
+#   Copyright 3DO Company, 1995
+#   All rights reserved.
+#
+
+#####################################
+#	Symbol definitions
+#####################################
+
+App				= lightgundemo
+DebugFlag		= 1
+SourceDir		= {3DOFolder}Examples:EventBroker:LightGun:
+ObjectDir		= :Objects:
+Apps_Data		= :Apps_Data:
+CC				= armcc
+LINK			= armlink
+WorkingDisk		=
+3DOAutoDup		= -y
+
+#####################################
+#	Default compiler options
+#####################################
+
+COptions			= -fa -zps0 -za1
+CDebugOptions		= -g -d DEBUG={DebugFlag}
+LOptions			= -aif -r -b 0x00
+LStackSize			= 4096
+LDebugOptions		= -d
+ModbinDebugOptions	= -debug
+
+#####################################
+#	Object files
+#####################################
+
+OBJECTS			=	 {ObjectDir}lightgun.c.o {ObjectDir}lightgundemo.c.o "{3DOLibs}"cstartup.o
+
+LIBS			=	 âˆ‚
+					"{3DOLibs}Lib3DO.lib" âˆ‚
+					"{3DOLibs}audio.lib" âˆ‚
+					"{3DOLibs}music.lib" âˆ‚
+					"{3DOLibs}operamath.lib" âˆ‚
+					"{3DOLibs}filesystem.lib" âˆ‚
+					"{3DOLibs}graphics.lib" âˆ‚
+					"{3DOLibs}input.lib" âˆ‚
+					"{3DOLibs}clib.lib"
+
+#####################################
+#	Default build rules
+#####################################
+
+All				Æ’	{App}
+
+{ObjectDir}		Æ’	:
+
+.c.o	Æ’	.c
+	{CC} -i "{3DOIncludes}" {COptions} {CDebugOptions} -o {TargDir}{Default}.c.o {DepDir}{Default}.c
+
+#####################################
+#	Target build rules
+#####################################
+
+{App} Æ’ {App}.make {OBJECTS}
+	{LINK} {LOptions} {LDebugOptions} âˆ‚
+		{OBJECTS} âˆ‚
+		{LIBS} âˆ‚
+		-o "{WorkingDisk}"{Targ}
+	SetFile "{WorkingDisk}"{Targ} -c 'EaDJ' -t 'PROJ'
+	modbin "{WorkingDisk}"{Targ} -stack {LStackSize} {ModbinDebugOptions}
+	stripaif "{WorkingDisk}"{Targ} -o {Targ} -s {Targ}.sym
+	move {3DOAutodup} {Targ} "{Apps_Data}"
+	move {3DOAutodup} {Targ}.sym "{Apps_Data}"
+
+#####################################
+#	Additional Target Dependencies
+#####################################
+
+{ObjectDir}lightgun.c.o			Æ’	{App}.make
+{ObjectDir}lightgundemo.c.o			Æ’	{App}.make
+

--- a/release/examples/ExamplesLib/exampleslib.make
+++ b/release/examples/ExamplesLib/exampleslib.make
@@ -1,1 +1,74 @@
-######################################### Copyright (C) 1995, an unpublished work by The 3DO Company. All rights reserved.## This material contains confidential information that is the property of The 3DO Company.## Any unauthorized duplication, disclosure or use is prohibited.## $Id: exampleslib.make,v 1.5 1995/01/20 04:20:45 ceckhaus Exp $########################################   File:       ExamplesLib.lib.make#   Target:     ExamplesLib.lib#   Sources:    controlpad.c effectshandler.c vdlutil.c getvideoinfo.c loopstereosoundfile.c#######################################	Symbol definitions#####################################Library			= ExamplesLibDebugFlag		= 1ObjectDir		= :Objects:SourceDir		= :CC				= armccLIBRARIAN		= armlibWorkingDisk		=######################################	Default compiler options#####################################COptions			= -fa -zps0 -za1CDebugOptions		= -g -d DEBUG={DebugFlag}LOptions			= -c -o######################################	Object files#####################################OBJECTS			=	{ObjectDir}controlpad.c.o ¶					{ObjectDir}effectshandler.c.o ¶					{ObjectDir}vdlutil.c.o ¶					{ObjectDir}getvideoinfo.c.o ¶					{ObjectDir}loopstereosoundfile.c.o######################################	Default build rules#####################################All				Ä	{Library}.lib{ObjectDir}		Ä	:.c.o	Ä	.c	{CC} -i "{3DOIncludes}" {COptions} {CDebugOptions} -o {TargDir}{Default}.c.o {DepDir}{Default}.c######################################	Target build rules#####################################{Library} Ä {Library}.make {OBJECTS}	{LIBRARIAN} {LOptions} ¶				{Library}.lib	¶				{OBJECTS}######################################	Additional Target Dependencies#####################################{ObjectDir}controlpad.c.o			Ä	"{SourceDir}"controlpad.h{ObjectDir}effectshandler.c.o		Ä	"{SourceDir}"effectshandler.h{ObjectDir}vdlutil.c.o				Ä	"{SourceDir}"vdlutil.h{ObjectDir}getvideoinfo.c.o			Ä	"{SourceDir}"getvideoinfo.h{ObjectDir}loopstereosoundfile.c.o	Ä	"{SourceDir}"loopstereosoundfile.h
+
+#####################################
+##
+## Copyright (C) 1995, an unpublished work by The 3DO Company. All rights reserved.
+## This material contains confidential information that is the property of The 3DO Company.
+## Any unauthorized duplication, disclosure or use is prohibited.
+## $Id: exampleslib.make,v 1.5 1995/01/20 04:20:45 ceckhaus Exp $
+##
+#####################################
+
+#   File:       ExamplesLib.lib.make
+#   Target:     ExamplesLib.lib
+#   Sources:    controlpad.c effectshandler.c vdlutil.c getvideoinfo.c loopstereosoundfile.c
+#
+
+#####################################
+#	Symbol definitions
+#####################################
+
+Library			= ExamplesLib
+DebugFlag		= 1
+ObjectDir		= :Objects:
+SourceDir		= :
+CC				= armcc
+LIBRARIAN		= armlib
+WorkingDisk		=
+
+#####################################
+#	Default compiler options
+#####################################
+
+COptions			= -fa -zps0 -za1
+CDebugOptions		= -g -d DEBUG={DebugFlag}
+LOptions			= -c -o
+
+#####################################
+#	Object files
+#####################################
+
+OBJECTS			=	{ObjectDir}controlpad.c.o âˆ‚
+					{ObjectDir}effectshandler.c.o âˆ‚
+					{ObjectDir}vdlutil.c.o âˆ‚
+					{ObjectDir}getvideoinfo.c.o âˆ‚
+					{ObjectDir}loopstereosoundfile.c.o
+
+#####################################
+#	Default build rules
+#####################################
+
+All				Æ’	{Library}.lib
+
+{ObjectDir}		Æ’	:
+
+.c.o	Æ’	.c
+	{CC} -i "{3DOIncludes}" {COptions} {CDebugOptions} -o {TargDir}{Default}.c.o {DepDir}{Default}.c
+
+#####################################
+#	Target build rules
+#####################################
+
+{Library} Æ’ {Library}.make {OBJECTS}
+	{LIBRARIAN} {LOptions} âˆ‚
+				{Library}.lib	âˆ‚
+				{OBJECTS}
+
+#####################################
+#	Additional Target Dependencies
+#####################################
+
+{ObjectDir}controlpad.c.o			Æ’	"{SourceDir}"controlpad.h
+{ObjectDir}effectshandler.c.o		Æ’	"{SourceDir}"effectshandler.h
+{ObjectDir}vdlutil.c.o				Æ’	"{SourceDir}"vdlutil.h
+{ObjectDir}getvideoinfo.c.o			Æ’	"{SourceDir}"getvideoinfo.h
+{ObjectDir}loopstereosoundfile.c.o	Æ’	"{SourceDir}"loopstereosoundfile.h

--- a/release/examples/FileSystem/filesystem.make
+++ b/release/examples/FileSystem/filesystem.make
@@ -1,1 +1,82 @@
-######################################### Copyright (C) 1995, an unpublished work by The 3DO Company. All rights reserved.## This material contains confidential information that is the property of The 3DO Company.## Any unauthorized duplication, disclosure or use is prohibited.## $Id: filesystem.make,v 1.3 1995/01/19 01:38:25 mattm Exp $########################################   File:       FileSystem.make#   Target:     allocate type walker ls#   Sources:    allocate.c type.c walker.c ls.c##   Copyright (c) 1995, The 3DO Company#   All rights reserved.#######################################	Symbol definitions#####################################App				= FileSystemDebugFlag		= 1SourceDir		= {3DOFolder}Examples:FileSystem:ObjectDir		= :Objects:ExecutableDir	= {SourceDir}Apps_Data:TempDir			= :CC				= armccLINK			= armlink######################################	Default compiler options#####################################COptions			= -fa -zps0 -za1CDebugOptions		= -g -d DEBUG={DebugFlag}LOptions			= -aif -r -b 0x00 -workspace 0x10000LStackSize			= 6000LDebugOptions		= -dModbinDebugOptions	= -debug######################################	Object files#####################################OBJECTS			=	{ObjectDir}allocate.c.o		¶					{ObjectDir}type.c.o		¶					{ObjectDir}walker.c.o	¶					{ObjectDir}ls.c.o					LIBS			=	"{3DOLibs}Lib3DO.lib" ¶					"{3DOLibs}audio.lib" ¶					"{3DOLibs}music.lib" ¶					"{3DOLibs}operamath.lib" ¶					"{3DOLibs}filesystem.lib" ¶					"{3DOLibs}graphics.lib" ¶					"{3DOLibs}input.lib" ¶					"{3DOLibs}memdebug.lib" ¶					"{3DOLibs}clib.lib"					######################################	Default build rules#####################################All				Ä	{App}{ObjectDir}		Ä	:.c.o	Ä	.c	{CC} -i "{3DOIncludes}" {COptions} {CDebugOptions} -o {TargDir}{Default}.c.o {DepDir}{Default}.c	{LINK} {LOptions} {LDebugOptions} ¶		{TargDir}{Default}.c.o ¶		"{3DOLibs}"cstartup.o ¶		{LIBS} ¶		-o {TempDir}{Default}.nostrip	SetFile {TempDir}{Default}.nostrip -c 'EaDJ' -t 'PROJ'	modbin {TempDir}{Default}.nostrip -stack {LStackSize} {ModbinDebugOptions}	stripaif {TempDir}{Default}.nostrip -o {ExecutableDir}{Default} -s {ExecutableDir}{Default}.sym	delete {TempDir}{Default}.nostrip{App} Ä {App}.make {OBJECTS}
+#####################################
+##
+## Copyright (C) 1995, an unpublished work by The 3DO Company. All rights reserved.
+## This material contains confidential information that is the property of The 3DO Company.
+## Any unauthorized duplication, disclosure or use is prohibited.
+## $Id: filesystem.make,v 1.3 1995/01/19 01:38:25 mattm Exp $
+##
+#####################################
+#   File:       FileSystem.make
+#   Target:     allocate type walker ls
+#   Sources:    allocate.c type.c walker.c ls.c
+#
+#   Copyright (c) 1995, The 3DO Company
+#   All rights reserved.
+#
+
+#####################################
+#	Symbol definitions
+#####################################
+
+App				= FileSystem
+DebugFlag		= 1
+
+SourceDir		= {3DOFolder}Examples:FileSystem:
+ObjectDir		= :Objects:
+ExecutableDir	= {SourceDir}Apps_Data:
+TempDir			= :
+
+CC				= armcc
+LINK			= armlink
+
+#####################################
+#	Default compiler options
+#####################################
+
+COptions			= -fa -zps0 -za1
+CDebugOptions		= -g -d DEBUG={DebugFlag}
+LOptions			= -aif -r -b 0x00 -workspace 0x10000
+LStackSize			= 6000
+LDebugOptions		= -d
+ModbinDebugOptions	= -debug
+
+#####################################
+#	Object files
+#####################################
+
+OBJECTS			=	{ObjectDir}allocate.c.o		âˆ‚
+					{ObjectDir}type.c.o		âˆ‚
+					{ObjectDir}walker.c.o	âˆ‚
+					{ObjectDir}ls.c.o
+					
+LIBS			=	"{3DOLibs}Lib3DO.lib" âˆ‚
+					"{3DOLibs}audio.lib" âˆ‚
+					"{3DOLibs}music.lib" âˆ‚
+					"{3DOLibs}operamath.lib" âˆ‚
+					"{3DOLibs}filesystem.lib" âˆ‚
+					"{3DOLibs}graphics.lib" âˆ‚
+					"{3DOLibs}input.lib" âˆ‚
+					"{3DOLibs}memdebug.lib" âˆ‚
+					"{3DOLibs}clib.lib"
+					
+#####################################
+#	Default build rules
+#####################################
+
+All				Æ’	{App}
+
+{ObjectDir}		Æ’	:
+
+.c.o	Æ’	.c
+	{CC} -i "{3DOIncludes}" {COptions} {CDebugOptions} -o {TargDir}{Default}.c.o {DepDir}{Default}.c
+	{LINK} {LOptions} {LDebugOptions} âˆ‚
+		{TargDir}{Default}.c.o âˆ‚
+		"{3DOLibs}"cstartup.o âˆ‚
+		{LIBS} âˆ‚
+		-o {TempDir}{Default}.nostrip
+	SetFile {TempDir}{Default}.nostrip -c 'EaDJ' -t 'PROJ'
+	modbin {TempDir}{Default}.nostrip -stack {LStackSize} {ModbinDebugOptions}
+	stripaif {TempDir}{Default}.nostrip -o {ExecutableDir}{Default} -s {ExecutableDir}{Default}.sym
+	delete {TempDir}{Default}.nostrip
+
+{App} Æ’ {App}.make {OBJECTS}

--- a/release/examples/Fonts/FontViewer/fontviewer.make
+++ b/release/examples/Fonts/FontViewer/fontviewer.make
@@ -1,1 +1,91 @@
-######################################### Copyright (C) 1995, an unpublished work by The 3DO Company. All rights reserved.## This material contains confidential information that is the property of The 3DO Company.## Any unauthorized duplication, disclosure or use is prohibited.## $Id: fontviewer.make,v 1.9 1995/01/20 04:54:40 ceckhaus Exp $########################################   File:       fontviewer.make#   Target:     fontviewer#   Sources:    fontviewer.c#######################################	Symbol definitions#####################################App				= fontviewerDebugFlag		= 1ObjectDir		= :Objects:SourceDir		= :AppsDir			= :Apps_Data:ExamplesLibDir	= {3DOFolder}Examples:ExamplesLib:CC				= armccLINK			= armlinkWorkingDisk		=######################################	Default compiler options#####################################COptions			= -fa -zps0 -za1 -i "{ExamplesLibDir}"CDebugOptions		= -g -d DEBUG={DebugFlag}LOptions			= -aif -r -b 0x00LStackSize			= 4096LDebugOptions		= -dModbinDebugOptions	= -debug######################################	Object files#####################################OBJECTS			=	{ObjectDir}{App}.c.o ¶					"{3DOLibs}"cstartup.oLIBS			=	¶					"{ExamplesLibDir}ExamplesLib.lib"  ¶					"{3DOLibs}Lib3DO.lib" ¶					"{3DOLibs}operamath.lib" ¶					"{3DOLibs}filesystem.lib" ¶					"{3DOLibs}graphics.lib" ¶					"{3DOLibs}input.lib" ¶					"{3DOLibs}clib.lib"######################################	Default build rules#####################################All				Ä	{App}{ObjectDir}		Ä	:.c.o	Ä	.c	{CC} -i "{3DOIncludes}" {COptions} {CDebugOptions} -o {TargDir}{Default}.c.o {DepDir}{Default}.c######################################	Target build rules#####################################{App} Ä {App}.make {OBJECTS}	{LINK} {LOptions} {LDebugOptions} ¶		{OBJECTS} ¶		{LIBS} ¶		-o "{WorkingDisk}"{Targ}	SetFile "{WorkingDisk}"{Targ} -c 'EaDJ' -t 'PROJ'	modbin "{WorkingDisk}"{Targ} -stack {LStackSize} {ModbinDebugOptions}	stripaif "{WorkingDisk}"{Targ} -o {Targ} -s {Targ}.sym	if not `exists "{AppsDir}"`		newFolder "{AppsDir}"	end	move -y {Targ} "{AppsDir}"	move -y {Targ}.sym "{AppsDir}"######################################	Additional Target Dependencies#####################################{ObjectDir}{App}.c.o		Ä	{App}.make
+
+#####################################
+##
+## Copyright (C) 1995, an unpublished work by The 3DO Company. All rights reserved.
+## This material contains confidential information that is the property of The 3DO Company.
+## Any unauthorized duplication, disclosure or use is prohibited.
+## $Id: fontviewer.make,v 1.9 1995/01/20 04:54:40 ceckhaus Exp $
+##
+#####################################
+
+#   File:       fontviewer.make
+#   Target:     fontviewer
+#   Sources:    fontviewer.c
+#
+
+#####################################
+#	Symbol definitions
+#####################################
+
+App				= fontviewer
+DebugFlag		= 1
+ObjectDir		= :Objects:
+SourceDir		= :
+AppsDir			= :Apps_Data:
+ExamplesLibDir	= {3DOFolder}Examples:ExamplesLib:
+CC				= armcc
+LINK			= armlink
+WorkingDisk		=
+
+#####################################
+#	Default compiler options
+#####################################
+
+COptions			= -fa -zps0 -za1 -i "{ExamplesLibDir}"
+CDebugOptions		= -g -d DEBUG={DebugFlag}
+LOptions			= -aif -r -b 0x00
+LStackSize			= 4096
+LDebugOptions		= -d
+ModbinDebugOptions	= -debug
+
+#####################################
+#	Object files
+#####################################
+
+OBJECTS			=	{ObjectDir}{App}.c.o âˆ‚
+					"{3DOLibs}"cstartup.o
+
+LIBS			=	âˆ‚
+					"{ExamplesLibDir}ExamplesLib.lib"  âˆ‚
+					"{3DOLibs}Lib3DO.lib" âˆ‚
+					"{3DOLibs}operamath.lib" âˆ‚
+					"{3DOLibs}filesystem.lib" âˆ‚
+					"{3DOLibs}graphics.lib" âˆ‚
+					"{3DOLibs}input.lib" âˆ‚
+					"{3DOLibs}clib.lib"
+
+#####################################
+#	Default build rules
+#####################################
+
+All				Æ’	{App}
+
+{ObjectDir}		Æ’	:
+
+.c.o	Æ’	.c
+	{CC} -i "{3DOIncludes}" {COptions} {CDebugOptions} -o {TargDir}{Default}.c.o {DepDir}{Default}.c
+
+#####################################
+#	Target build rules
+#####################################
+
+{App} Æ’ {App}.make {OBJECTS}
+	{LINK} {LOptions} {LDebugOptions} âˆ‚
+		{OBJECTS} âˆ‚
+		{LIBS} âˆ‚
+		-o "{WorkingDisk}"{Targ}
+	SetFile "{WorkingDisk}"{Targ} -c 'EaDJ' -t 'PROJ'
+	modbin "{WorkingDisk}"{Targ} -stack {LStackSize} {ModbinDebugOptions}
+	stripaif "{WorkingDisk}"{Targ} -o {Targ} -s {Targ}.sym
+	if not `exists "{AppsDir}"`
+		newFolder "{AppsDir}"
+	end
+	move -y {Targ} "{AppsDir}"
+	move -y {Targ}.sym "{AppsDir}"
+
+#####################################
+#	Additional Target Dependencies
+#####################################
+
+{ObjectDir}{App}.c.o		Æ’	{App}.make
+

--- a/release/examples/Fonts/Font_Library_Example/fontlibexample.make
+++ b/release/examples/Fonts/Font_Library_Example/fontlibexample.make
@@ -1,1 +1,91 @@
-######################################### Copyright (C) 1995, an unpublished work by The 3DO Company. All rights reserved.## This material contains confidential information that is the property of The 3DO Company.## Any unauthorized duplication, disclosure or use is prohibited.## $Id: fontlibexample.make,v 1.5 1995/01/20 04:51:32 ceckhaus Exp $########################################   File:       fontlibexample.make#   Target:     fontlibexample#   Sources:    fontlibexample.c#######################################	Symbol definitions#####################################App				= fontlibexampleDebugFlag		= 1ObjectDir		= :Objects:SourceDir		= :AppsDir			= :Apps_Data:ExamplesLibDir	= {3DOFolder}Examples:ExamplesLib:CC				= armccLINK			= armlinkWorkingDisk		= ######################################	Default compiler options#####################################COptions			= -fa -zps0 -za1 -i "{ExamplesLibDir}"CDebugOptions		= -g -d DEBUG={DebugFlag}LOptions			= -aif -r -b 0x00LStackSize			= 4096LDebugOptions		= -dModbinDebugOptions	= -debug######################################	Object files#####################################OBJECTS			=	{ObjectDir}{App}.c.o ¶					"{3DOLibs}"cstartup.oLIBS			=	¶					"{ExamplesLibDir}ExamplesLib.lib"  ¶					"{3DOLibs}Lib3DO.lib" ¶					"{3DOLibs}operamath.lib" ¶					"{3DOLibs}filesystem.lib" ¶					"{3DOLibs}graphics.lib" ¶					"{3DOLibs}input.lib" ¶					"{3DOLibs}clib.lib"					######################################	Default build rules#####################################All				Ä	{App}{ObjectDir}		Ä	:.c.o	Ä	.c	{CC} -i "{3DOIncludes}" {COptions} {CDebugOptions} -o {TargDir}{Default}.c.o {DepDir}{Default}.c######################################	Target build rules#####################################{App} Ä {App}.make {OBJECTS}	{LINK} {LOptions} {LDebugOptions} ¶		{OBJECTS} ¶		{LIBS} ¶		-o "{WorkingDisk}"{Targ}	SetFile "{WorkingDisk}"{Targ} -c 'EaDJ' -t 'PROJ'	modbin "{WorkingDisk}"{Targ} -stack {LStackSize} {ModbinDebugOptions}	stripaif "{WorkingDisk}"{Targ} -o {Targ} -s {Targ}.sym	if not `exists "{AppsDir}"`		newFolder "{AppsDir}"	end	move -y {Targ} "{AppsDir}"	move -y {Targ}.sym "{AppsDir}"######################################	Additional Target Dependencies#####################################{ObjectDir}{App}.c.o		Ä	{App}.make
+
+#####################################
+##
+## Copyright (C) 1995, an unpublished work by The 3DO Company. All rights reserved.
+## This material contains confidential information that is the property of The 3DO Company.
+## Any unauthorized duplication, disclosure or use is prohibited.
+## $Id: fontlibexample.make,v 1.5 1995/01/20 04:51:32 ceckhaus Exp $
+##
+#####################################
+
+#   File:       fontlibexample.make
+#   Target:     fontlibexample
+#   Sources:    fontlibexample.c
+#
+
+#####################################
+#	Symbol definitions
+#####################################
+
+App				= fontlibexample
+DebugFlag		= 1
+ObjectDir		= :Objects:
+SourceDir		= :
+AppsDir			= :Apps_Data:
+ExamplesLibDir	= {3DOFolder}Examples:ExamplesLib:
+CC				= armcc
+LINK			= armlink
+WorkingDisk		= 
+
+#####################################
+#	Default compiler options
+#####################################
+
+COptions			= -fa -zps0 -za1 -i "{ExamplesLibDir}"
+CDebugOptions		= -g -d DEBUG={DebugFlag}
+LOptions			= -aif -r -b 0x00
+LStackSize			= 4096
+LDebugOptions		= -d
+ModbinDebugOptions	= -debug
+
+#####################################
+#	Object files
+#####################################
+
+OBJECTS			=	{ObjectDir}{App}.c.o âˆ‚
+					"{3DOLibs}"cstartup.o
+
+LIBS			=	âˆ‚
+					"{ExamplesLibDir}ExamplesLib.lib"  âˆ‚
+					"{3DOLibs}Lib3DO.lib" âˆ‚
+					"{3DOLibs}operamath.lib" âˆ‚
+					"{3DOLibs}filesystem.lib" âˆ‚
+					"{3DOLibs}graphics.lib" âˆ‚
+					"{3DOLibs}input.lib" âˆ‚
+					"{3DOLibs}clib.lib"
+					
+#####################################
+#	Default build rules
+#####################################
+
+All				Æ’	{App}
+
+{ObjectDir}		Æ’	:
+
+.c.o	Æ’	.c
+	{CC} -i "{3DOIncludes}" {COptions} {CDebugOptions} -o {TargDir}{Default}.c.o {DepDir}{Default}.c
+
+#####################################
+#	Target build rules
+#####################################
+
+{App} Æ’ {App}.make {OBJECTS}
+	{LINK} {LOptions} {LDebugOptions} âˆ‚
+		{OBJECTS} âˆ‚
+		{LIBS} âˆ‚
+		-o "{WorkingDisk}"{Targ}
+	SetFile "{WorkingDisk}"{Targ} -c 'EaDJ' -t 'PROJ'
+	modbin "{WorkingDisk}"{Targ} -stack {LStackSize} {ModbinDebugOptions}
+	stripaif "{WorkingDisk}"{Targ} -o {Targ} -s {Targ}.sym
+	if not `exists "{AppsDir}"`
+		newFolder "{AppsDir}"
+	end
+	move -y {Targ} "{AppsDir}"
+	move -y {Targ}.sym "{AppsDir}"
+
+#####################################
+#	Additional Target Dependencies
+#####################################
+
+{ObjectDir}{App}.c.o		Æ’	{App}.make
+

--- a/release/examples/Fonts/Kanji_FontViewer/kanjifontviewer.make
+++ b/release/examples/Fonts/Kanji_FontViewer/kanjifontviewer.make
@@ -1,1 +1,94 @@
-######################################### Copyright (C) 1995, an unpublished work by The 3DO Company. All rights reserved.## This material contains confidential information that is the property of The 3DO Company.## Any unauthorized duplication, disclosure or use is prohibited.## $Id: kanjifontviewer.make,v 1.6 1995/01/20 04:54:52 ceckhaus Exp $########################################   File:       kanjifontviewer.make#   Target:     kanjifontviewer#   Sources:    kanjifontviewer.c ktextbox.c#######################################	Symbol definitions#####################################App				=  kanjifontviewerDebugFlag		= 1ObjectDir		= :Objects:SourceDir		= :AppsDir			= :Apps_Data:ExamplesLibDir	= {3DOFolder}Examples:ExamplesLib:CC				= armccLINK			= armlinkWorkingDisk		=######################################	Default compiler options#####################################COptions			= -fa -zps0 -za1 -i "{ExamplesLibDir}"CDebugOptions		= -g -d DEBUG={DebugFlag}LOptions			= -aif -r -b 0x00LStackSize			= 4096LDebugOptions		= -dModbinDebugOptions	= -debug######################################	Object files#####################################OBJECTS			=	{ObjectDir}{App}.c.o		¶					{ObjectDir}timehelper.c.o	¶					{ObjectDir}ktextbox.c.o		¶					"{3DOLibs}"cstartup.oLIBS			=	¶					"{ExamplesLibDir}ExamplesLib.lib"  ¶					"{3DOLibs}Lib3DO.lib" ¶					"{3DOLibs}operamath.lib" ¶					"{3DOLibs}filesystem.lib" ¶					"{3DOLibs}graphics.lib" ¶					"{3DOLibs}input.lib" ¶					"{3DOLibs}clib.lib"######################################	Default build rules#####################################All				Ä	{App}{ObjectDir}		Ä	:.c.o	Ä	.c	{CC} -i "{3DOIncludes}" {COptions} {CDebugOptions} -o {TargDir}{Default}.c.o {DepDir}{Default}.c######################################	Target build rules#####################################{App} Ä {App}.make {OBJECTS}	{LINK} {LOptions} {LDebugOptions} ¶		{OBJECTS} ¶		{LIBS} ¶		-o "{WorkingDisk}"{Targ}	SetFile "{WorkingDisk}"{Targ} -c 'EaDJ' -t 'PROJ'	modbin "{WorkingDisk}"{Targ} -stack {LStackSize} {ModbinDebugOptions}	stripaif "{WorkingDisk}"{Targ} -o {Targ} -s {Targ}.sym	if not `exists "{AppsDir}"`		newFolder "{AppsDir}"	end	move -y {Targ} "{AppsDir}"	move -y {Targ}.sym "{AppsDir}"######################################	Additional Target Dependencies#####################################{ObjectDir}{App}.c.o		Ä	{App}.make ktextbox.h ktextbox_error.h timehelper.h{ObjectDir}timehelper.c.o	Ä	timehelper.h{ObjectDir}ktextbox.c.o		Ä	ktextbox.h ktextbox_error.h
+
+#####################################
+##
+## Copyright (C) 1995, an unpublished work by The 3DO Company. All rights reserved.
+## This material contains confidential information that is the property of The 3DO Company.
+## Any unauthorized duplication, disclosure or use is prohibited.
+## $Id: kanjifontviewer.make,v 1.6 1995/01/20 04:54:52 ceckhaus Exp $
+##
+#####################################
+
+#   File:       kanjifontviewer.make
+#   Target:     kanjifontviewer
+#   Sources:    kanjifontviewer.c ktextbox.c
+#
+
+#####################################
+#	Symbol definitions
+#####################################
+
+App				=  kanjifontviewer
+DebugFlag		= 1
+ObjectDir		= :Objects:
+SourceDir		= :
+AppsDir			= :Apps_Data:
+ExamplesLibDir	= {3DOFolder}Examples:ExamplesLib:
+CC				= armcc
+LINK			= armlink
+WorkingDisk		=
+
+#####################################
+#	Default compiler options
+#####################################
+
+COptions			= -fa -zps0 -za1 -i "{ExamplesLibDir}"
+CDebugOptions		= -g -d DEBUG={DebugFlag}
+LOptions			= -aif -r -b 0x00
+LStackSize			= 4096
+LDebugOptions		= -d
+ModbinDebugOptions	= -debug
+
+#####################################
+#	Object files
+#####################################
+
+OBJECTS			=	{ObjectDir}{App}.c.o		âˆ‚
+					{ObjectDir}timehelper.c.o	âˆ‚
+					{ObjectDir}ktextbox.c.o		âˆ‚
+					"{3DOLibs}"cstartup.o
+
+LIBS			=	âˆ‚
+					"{ExamplesLibDir}ExamplesLib.lib"  âˆ‚
+					"{3DOLibs}Lib3DO.lib" âˆ‚
+					"{3DOLibs}operamath.lib" âˆ‚
+					"{3DOLibs}filesystem.lib" âˆ‚
+					"{3DOLibs}graphics.lib" âˆ‚
+					"{3DOLibs}input.lib" âˆ‚
+					"{3DOLibs}clib.lib"
+
+#####################################
+#	Default build rules
+#####################################
+
+All				Æ’	{App}
+
+{ObjectDir}		Æ’	:
+
+.c.o	Æ’	.c
+	{CC} -i "{3DOIncludes}" {COptions} {CDebugOptions} -o {TargDir}{Default}.c.o {DepDir}{Default}.c
+
+#####################################
+#	Target build rules
+#####################################
+
+{App} Æ’ {App}.make {OBJECTS}
+	{LINK} {LOptions} {LDebugOptions} âˆ‚
+		{OBJECTS} âˆ‚
+		{LIBS} âˆ‚
+		-o "{WorkingDisk}"{Targ}
+	SetFile "{WorkingDisk}"{Targ} -c 'EaDJ' -t 'PROJ'
+	modbin "{WorkingDisk}"{Targ} -stack {LStackSize} {ModbinDebugOptions}
+	stripaif "{WorkingDisk}"{Targ} -o {Targ} -s {Targ}.sym
+	if not `exists "{AppsDir}"`
+		newFolder "{AppsDir}"
+	end
+	move -y {Targ} "{AppsDir}"
+	move -y {Targ}.sym "{AppsDir}"
+
+#####################################
+#	Additional Target Dependencies
+#####################################
+
+{ObjectDir}{App}.c.o		Æ’	{App}.make ktextbox.h ktextbox_error.h timehelper.h
+{ObjectDir}timehelper.c.o	Æ’	timehelper.h
+{ObjectDir}ktextbox.c.o		Æ’	ktextbox.h ktextbox_error.h

--- a/release/examples/Graphics/3DO_Bounce/bounce.make
+++ b/release/examples/Graphics/3DO_Bounce/bounce.make
@@ -1,1 +1,95 @@
-######################################### Copyright (C) 1995, an unpublished work by The 3DO Company. All rights reserved.## This material contains confidential information that is the property of The 3DO Company.## Any unauthorized duplication, disclosure or use is prohibited.## $Id: bounce.make,v 1.8 1995/01/20 04:50:51 ceckhaus Exp $########################################   File:       bounce.make#   Target:     bounce#   Sources:    bounce.c bounce_sound.c#######################################	Symbol definitions#####################################App				= bounceDebugFlag		= 1ObjectDir		= :Objects:SourceDir		= :AppsDir			= :Apps_Data:ExamplesLibDir	= {3DOFolder}Examples:ExamplesLib:CC				= armccLINK			= armlinkWorkingDisk		=######################################	Default compiler options#####################################COptions			= -fa -zps0 -za1 -i "{ExamplesLibDir}"CDebugOptions		= -g -d DEBUG={DebugFlag}LOptions			= -aif -r -b 0x00LStackSize			= 4096LDebugOptions		= -dModbinDebugOptions	= -debug######################################	Object files#####################################OBJECTS			=	{ObjectDir}bounce.c.o ¶					{ObjectDir}bounce_sound.c.o ¶					"{3DOLibs}"cstartup.oLIBS			=	¶					"{ExamplesLibDir}ExamplesLib.lib"  ¶					"{3DOLibs}Lib3DO.lib" ¶					"{3DOLibs}audio.lib" ¶					"{3DOLibs}music.lib" ¶					"{3DOLibs}operamath.lib" ¶					"{3DOLibs}filesystem.lib" ¶					"{3DOLibs}graphics.lib" ¶					"{3DOLibs}input.lib" ¶					"{3DOLibs}clib.lib"######################################	Default build rules#####################################All				Ä	{App}{ObjectDir}		Ä	:.c.o	Ä	.c	{CC} -i "{3DOIncludes}" {COptions} {CDebugOptions} -o {TargDir}{Default}.c.o {DepDir}{Default}.c######################################	Target build rules#####################################{App} Ä {App}.make {OBJECTS}	{LINK} {LOptions} {LDebugOptions} ¶		{OBJECTS} ¶		{LIBS} ¶		-o "{WorkingDisk}"{Targ}	SetFile "{WorkingDisk}"{Targ} -c 'EaDJ' -t 'PROJ'	modbin "{WorkingDisk}"{Targ} -stack {LStackSize} {ModbinDebugOptions}	stripaif "{WorkingDisk}"{Targ} -o {Targ} -s {Targ}.sym	if not `exists "{AppsDir}"`		newFolder "{AppsDir}"	end	move -y {Targ} "{AppsDir}"	move -y {Targ}.sym "{AppsDir}"######################################	Additional Target Dependencies#####################################{ObjectDir}bounce.c.o		Ä	{App}.make bounce.h bounce_sound.h{ObjectDir}bounce_sound.c.o	Ä 	{App}.make bounce_sound.h
+
+#####################################
+##
+## Copyright (C) 1995, an unpublished work by The 3DO Company. All rights reserved.
+## This material contains confidential information that is the property of The 3DO Company.
+## Any unauthorized duplication, disclosure or use is prohibited.
+## $Id: bounce.make,v 1.8 1995/01/20 04:50:51 ceckhaus Exp $
+##
+#####################################
+
+#   File:       bounce.make
+#   Target:     bounce
+#   Sources:    bounce.c bounce_sound.c
+#
+
+#####################################
+#	Symbol definitions
+#####################################
+
+App				= bounce
+DebugFlag		= 1
+ObjectDir		= :Objects:
+SourceDir		= :
+AppsDir			= :Apps_Data:
+ExamplesLibDir	= {3DOFolder}Examples:ExamplesLib:
+CC				= armcc
+LINK			= armlink
+WorkingDisk		=
+
+#####################################
+#	Default compiler options
+#####################################
+
+COptions			= -fa -zps0 -za1 -i "{ExamplesLibDir}"
+CDebugOptions		= -g -d DEBUG={DebugFlag}
+LOptions			= -aif -r -b 0x00
+LStackSize			= 4096
+LDebugOptions		= -d
+ModbinDebugOptions	= -debug
+
+#####################################
+#	Object files
+#####################################
+
+OBJECTS			=	{ObjectDir}bounce.c.o âˆ‚
+					{ObjectDir}bounce_sound.c.o âˆ‚
+					"{3DOLibs}"cstartup.o
+
+LIBS			=	âˆ‚
+					"{ExamplesLibDir}ExamplesLib.lib"  âˆ‚
+					"{3DOLibs}Lib3DO.lib" âˆ‚
+					"{3DOLibs}audio.lib" âˆ‚
+					"{3DOLibs}music.lib" âˆ‚
+					"{3DOLibs}operamath.lib" âˆ‚
+					"{3DOLibs}filesystem.lib" âˆ‚
+					"{3DOLibs}graphics.lib" âˆ‚
+					"{3DOLibs}input.lib" âˆ‚
+					"{3DOLibs}clib.lib"
+
+#####################################
+#	Default build rules
+#####################################
+
+All				Æ’	{App}
+
+{ObjectDir}		Æ’	:
+
+.c.o	Æ’	.c
+	{CC} -i "{3DOIncludes}" {COptions} {CDebugOptions} -o {TargDir}{Default}.c.o {DepDir}{Default}.c
+
+#####################################
+#	Target build rules
+#####################################
+
+{App} Æ’ {App}.make {OBJECTS}
+	{LINK} {LOptions} {LDebugOptions} âˆ‚
+		{OBJECTS} âˆ‚
+		{LIBS} âˆ‚
+		-o "{WorkingDisk}"{Targ}
+	SetFile "{WorkingDisk}"{Targ} -c 'EaDJ' -t 'PROJ'
+	modbin "{WorkingDisk}"{Targ} -stack {LStackSize} {ModbinDebugOptions}
+	stripaif "{WorkingDisk}"{Targ} -o {Targ} -s {Targ}.sym
+	if not `exists "{AppsDir}"`
+		newFolder "{AppsDir}"
+	end
+	move -y {Targ} "{AppsDir}"
+	move -y {Targ}.sym "{AppsDir}"
+
+#####################################
+#	Additional Target Dependencies
+#####################################
+
+{ObjectDir}bounce.c.o		Æ’	{App}.make bounce.h bounce_sound.h
+{ObjectDir}bounce_sound.c.o	Æ’ 	{App}.make bounce_sound.h
+

--- a/release/examples/Graphics/3DO_Orbit/3doorbit.make
+++ b/release/examples/Graphics/3DO_Orbit/3doorbit.make
@@ -1,1 +1,87 @@
-######################################### Copyright (C) 1995, an unpublished work by The 3DO Company. All rights reserved.## This material contains confidential information that is the property of The 3DO Company.## Any unauthorized duplication, disclosure or use is prohibited.## $Id: 3doorbit.make,v 1.7 1995/01/16 19:43:34 gyld Exp $#############################################################################	Symbol definitions#####################################App				= 3doorbitDebugFlag		= 1ObjectDir		= :Objects:SourceDir		= :AppsDir			= :Apps_Data:ExampleLibDir		= {3DOFolder}Examples:ExamplesLib:CC				= armccLINK			= armlinkWorkingDisk		=######################################	Default compiler options#####################################COptions			= -fa -zps0 -za1 -i "{ExampleLibDir}"CDebugOptions		= -g -d DEBUG={DebugFlag}LOptions			= -aif -r -b 0x00LStackSize			= 4096LDebugOptions		= -dModbinDebugOptions	= -debug######################################	Object files#####################################OBJECTS			=	 {ObjectDir}orbit.c.o "{3DOLibs}"cstartup.oLIBS			=	 ¶					"{ExampleLibDir}ExamplesLib.lib"  ¶					"{3DOLibs}Lib3DO.lib" ¶					"{3DOLibs}audio.lib" ¶					"{3DOLibs}music.lib" ¶					"{3DOLibs}operamath.lib" ¶					"{3DOLibs}filesystem.lib" ¶					"{3DOLibs}graphics.lib" ¶					"{3DOLibs}input.lib" ¶					"{3DOLibs}clib.lib"######################################	Default build rules#####################################All				Ä	{App}{ObjectDir}		Ä	:.c.o	Ä	.c	{CC} -i "{3DOIncludes}" {COptions} {CDebugOptions} -o {TargDir}{Default}.c.o {DepDir}{Default}.c######################################	Target build rules#####################################{App} Ä {App}.make {OBJECTS}	{LINK} {LOptions} {LDebugOptions} ¶		{OBJECTS} ¶		{LIBS} ¶		-o "{WorkingDisk}"{Targ}	SetFile "{WorkingDisk}"{Targ} -c 'EaDJ' -t PROJ	modbin "{WorkingDisk}"{Targ} -stack {LStackSize} {ModbinDebugOptions}	stripaif "{WorkingDisk}"{Targ} -o {Targ} -s {Targ}.sym	if not `exists "{AppsDir}"`		newFolder "{AppsDir}"	end	move -y {Targ} "{AppsDir}"	move -y {Targ}.sym "{AppsDir}"######################################	Additional Target Dependencies#####################################{ObjectDir}orbit.c.o			Ä	{App}.make "{SourceDir}"orbit.h "{SourceDir}"orbiterror.h
+#####################################
+##
+## Copyright (C) 1995, an unpublished work by The 3DO Company. All rights reserved.
+## This material contains confidential information that is the property of The 3DO Company.
+## Any unauthorized duplication, disclosure or use is prohibited.
+## $Id: 3doorbit.make,v 1.7 1995/01/16 19:43:34 gyld Exp $
+##
+#####################################
+
+#####################################
+#	Symbol definitions
+#####################################
+
+App				= 3doorbit
+DebugFlag		= 1
+ObjectDir		= :Objects:
+SourceDir		= :
+AppsDir			= :Apps_Data:
+ExampleLibDir		= {3DOFolder}Examples:ExamplesLib:
+CC				= armcc
+LINK			= armlink
+WorkingDisk		=
+
+#####################################
+#	Default compiler options
+#####################################
+
+COptions			= -fa -zps0 -za1 -i "{ExampleLibDir}"
+CDebugOptions		= -g -d DEBUG={DebugFlag}
+LOptions			= -aif -r -b 0x00
+LStackSize			= 4096
+LDebugOptions		= -d
+ModbinDebugOptions	= -debug
+
+#####################################
+#	Object files
+#####################################
+
+OBJECTS			=	 {ObjectDir}orbit.c.o "{3DOLibs}"cstartup.o
+
+LIBS			=	 âˆ‚
+					"{ExampleLibDir}ExamplesLib.lib"  âˆ‚
+					"{3DOLibs}Lib3DO.lib" âˆ‚
+					"{3DOLibs}audio.lib" âˆ‚
+					"{3DOLibs}music.lib" âˆ‚
+					"{3DOLibs}operamath.lib" âˆ‚
+					"{3DOLibs}filesystem.lib" âˆ‚
+					"{3DOLibs}graphics.lib" âˆ‚
+					"{3DOLibs}input.lib" âˆ‚
+					"{3DOLibs}clib.lib"
+
+#####################################
+#	Default build rules
+#####################################
+
+All				Æ’	{App}
+
+{ObjectDir}		Æ’	:
+
+.c.o	Æ’	.c
+	{CC} -i "{3DOIncludes}" {COptions} {CDebugOptions} -o {TargDir}{Default}.c.o {DepDir}{Default}.c
+
+#####################################
+#	Target build rules
+#####################################
+
+{App} Æ’ {App}.make {OBJECTS}
+	{LINK} {LOptions} {LDebugOptions} âˆ‚
+		{OBJECTS} âˆ‚
+		{LIBS} âˆ‚
+		-o "{WorkingDisk}"{Targ}
+	SetFile "{WorkingDisk}"{Targ} -c 'EaDJ' -t PROJ
+	modbin "{WorkingDisk}"{Targ} -stack {LStackSize} {ModbinDebugOptions}
+	stripaif "{WorkingDisk}"{Targ} -o {Targ} -s {Targ}.sym
+	if not `exists "{AppsDir}"`
+		newFolder "{AppsDir}"
+	end
+	move -y {Targ} "{AppsDir}"
+	move -y {Targ}.sym "{AppsDir}"
+
+
+#####################################
+#	Additional Target Dependencies
+#####################################
+
+{ObjectDir}orbit.c.o			Æ’	{App}.make "{SourceDir}"orbit.h "{SourceDir}"orbiterror.h
+

--- a/release/examples/Graphics/AnimSample/animsample.make
+++ b/release/examples/Graphics/AnimSample/animsample.make
@@ -1,1 +1,87 @@
-######################################### Copyright (C) 1995, an unpublished work by The 3DO Company. All rights reserved.## This material contains confidential information that is the property of The 3DO Company.## Any unauthorized duplication, disclosure or use is prohibited.## $Id: animsample.make,v 1.11 1995/01/16 19:45:54 gyld Exp $#############################################################################	Symbol definitions#####################################App				= animsampleDebugFlag		= 1ObjectDir		= :Objects:SourceDir		= :AppsDir			= :Apps_Data:ExampleLibDir			= {3DOFolder}Examples:ExamplesLib:CC				= armccLINK			= armlinkWorkingDisk		=######################################	Default compiler options#####################################COptions			= -fa -zps0 -za1 -i "{ExampleLibDir}"CDebugOptions		= -g -d DEBUG={DebugFlag}LOptions			= -aif -r -b 0x00LStackSize			= 4096LDebugOptions		= -dModbinDebugOptions	= -debug######################################	Object files#####################################OBJECTS			=	 {ObjectDir}animsample.c.o "{3DOLibs}"cstartup.oLIBS			=	 ¶					"{ExampleLibDir}ExamplesLib.lib" ¶					"{3DOLibs}Lib3DO.lib" ¶					"{3DOLibs}audio.lib" ¶					"{3DOLibs}music.lib" ¶					"{3DOLibs}operamath.lib" ¶					"{3DOLibs}filesystem.lib" ¶					"{3DOLibs}graphics.lib" ¶					"{3DOLibs}input.lib" ¶					"{3DOLibs}clib.lib"######################################	Default build rules#####################################All				Ä	{App}{ObjectDir}		Ä	:.c.o	Ä	.c	{CC} -i "{3DOIncludes}" {COptions} {CDebugOptions} -o {TargDir}{Default}.c.o {DepDir}{Default}.c######################################	Target build rules#####################################{App} Ä {App}.make {OBJECTS}	{LINK} {LOptions} {LDebugOptions} ¶		{OBJECTS} ¶		{LIBS} ¶		-o "{WorkingDisk}"{Targ}	SetFile "{WorkingDisk}"{Targ} -c 'EaDJ' -t PROJ	modbin "{WorkingDisk}"{Targ} -stack {LStackSize} {ModbinDebugOptions}	stripaif "{WorkingDisk}"{Targ} -o {Targ} -s {Targ}.sym	if not `exists "{AppsDir}"`		newFolder "{AppsDir}"	end	move -y {Targ} "{AppsDir}"	move -y {Targ}.sym "{AppsDir}"######################################	Additional Target Dependencies#####################################{ObjectDir}animsample.c.o			Ä	{App}.make "{SourceDir}"animsample.h "{SourceDir}"animerror.h
+#####################################
+##
+## Copyright (C) 1995, an unpublished work by The 3DO Company. All rights reserved.
+## This material contains confidential information that is the property of The 3DO Company.
+## Any unauthorized duplication, disclosure or use is prohibited.
+## $Id: animsample.make,v 1.11 1995/01/16 19:45:54 gyld Exp $
+##
+#####################################
+
+#####################################
+#	Symbol definitions
+#####################################
+
+App				= animsample
+DebugFlag		= 1
+ObjectDir		= :Objects:
+SourceDir		= :
+AppsDir			= :Apps_Data:
+ExampleLibDir			= {3DOFolder}Examples:ExamplesLib:
+CC				= armcc
+LINK			= armlink
+WorkingDisk		=
+
+#####################################
+#	Default compiler options
+#####################################
+
+COptions			= -fa -zps0 -za1 -i "{ExampleLibDir}"
+CDebugOptions		= -g -d DEBUG={DebugFlag}
+LOptions			= -aif -r -b 0x00
+LStackSize			= 4096
+LDebugOptions		= -d
+ModbinDebugOptions	= -debug
+
+#####################################
+#	Object files
+#####################################
+
+OBJECTS			=	 {ObjectDir}animsample.c.o "{3DOLibs}"cstartup.o
+
+LIBS			=	 âˆ‚
+					"{ExampleLibDir}ExamplesLib.lib" âˆ‚
+					"{3DOLibs}Lib3DO.lib" âˆ‚
+					"{3DOLibs}audio.lib" âˆ‚
+					"{3DOLibs}music.lib" âˆ‚
+					"{3DOLibs}operamath.lib" âˆ‚
+					"{3DOLibs}filesystem.lib" âˆ‚
+					"{3DOLibs}graphics.lib" âˆ‚
+					"{3DOLibs}input.lib" âˆ‚
+					"{3DOLibs}clib.lib"
+
+#####################################
+#	Default build rules
+#####################################
+
+All				Æ’	{App}
+
+{ObjectDir}		Æ’	:
+
+.c.o	Æ’	.c
+	{CC} -i "{3DOIncludes}" {COptions} {CDebugOptions} -o {TargDir}{Default}.c.o {DepDir}{Default}.c
+
+#####################################
+#	Target build rules
+#####################################
+
+{App} Æ’ {App}.make {OBJECTS}
+	{LINK} {LOptions} {LDebugOptions} âˆ‚
+		{OBJECTS} âˆ‚
+		{LIBS} âˆ‚
+		-o "{WorkingDisk}"{Targ}
+	SetFile "{WorkingDisk}"{Targ} -c 'EaDJ' -t PROJ
+	modbin "{WorkingDisk}"{Targ} -stack {LStackSize} {ModbinDebugOptions}
+	stripaif "{WorkingDisk}"{Targ} -o {Targ} -s {Targ}.sym
+	if not `exists "{AppsDir}"`
+		newFolder "{AppsDir}"
+	end
+	move -y {Targ} "{AppsDir}"
+	move -y {Targ}.sym "{AppsDir}"
+
+
+#####################################
+#	Additional Target Dependencies
+#####################################
+
+{ObjectDir}animsample.c.o			Æ’	{App}.make "{SourceDir}"animsample.h "{SourceDir}"animerror.h
+

--- a/release/examples/Graphics/ColorEcho/colorecho.make
+++ b/release/examples/Graphics/ColorEcho/colorecho.make
@@ -1,1 +1,82 @@
-######################################### Copyright (C) 1995, an unpublished work by The 3DO Company. All rights reserved.## This material contains confidential information that is the property of The 3DO Company.## Any unauthorized duplication, disclosure or use is prohibited.## $Id: colorecho.make,v 1.7 1995/01/16 19:46:30 gyld Exp $#############################################################################	Symbol definitions#####################################App				= colorechoDebugFlag		= 1AppsDir			= :Apps_Data:ObjectDir		= :Objects:CC				= armccLINK			= armlinkWorkingDisk		=######################################	Default compiler options#####################################COptions			= -fa -zps0 -za1CDebugOptions		= -g -d DEBUG={DebugFlag}LOptions			= -aif -r -b 0x00LStackSize			= 4096LDebugOptions		= -dModbinDebugOptions	= -debug######################################	Object files#####################################OBJECTS			=	 {ObjectDir}colorecho.c.o {ObjectDir}colorecho_tools.c.o "{3DOLibs}"cstartup.oLIBS			=	 ¶					"{3DOLibs}Lib3DO.lib" ¶					"{3DOLibs}music.lib" ¶					"{3DOLibs}audio.lib" ¶					"{3DOLibs}operamath.lib" ¶					"{3DOLibs}graphics.lib" ¶					"{3DOLibs}input.lib" ¶					"{3DOLibs}clib.lib"######################################	Default build rules#####################################All				Ä	{App}{ObjectDir}		Ä	:.c.o	Ä	.c	{CC} -i "{3DOIncludes}" {COptions} {CDebugOptions} -o {TargDir}{Default}.c.o {DepDir}{Default}.c######################################	Target build rules#####################################{App} Ä {App}.make {OBJECTS}	{LINK} {LOptions} {LDebugOptions} ¶		{OBJECTS} ¶		{LIBS} ¶		-o "{WorkingDisk}"{Targ}	SetFile "{WorkingDisk}"{Targ} -c 'EaDJ' -t PROJ	modbin "{WorkingDisk}"{Targ} -stack {LStackSize} {ModbinDebugOptions}	stripaif "{WorkingDisk}"{Targ} -o {Targ} -s {Targ}.sym	if not `exists "{AppsDir}"`		newFolder "{AppsDir}"	end	move -y {Targ} "{AppsDir}"	move -y {Targ}.sym "{AppsDir}"######################################	Additional Target Dependencies#####################################{ObjectDir}colorecho.c.o			Ä	{App}.make{ObjectDir}colorecho_tools.c.o			Ä	{App}.make
+#####################################
+##
+## Copyright (C) 1995, an unpublished work by The 3DO Company. All rights reserved.
+## This material contains confidential information that is the property of The 3DO Company.
+## Any unauthorized duplication, disclosure or use is prohibited.
+## $Id: colorecho.make,v 1.7 1995/01/16 19:46:30 gyld Exp $
+##
+#####################################
+
+#####################################
+#	Symbol definitions
+#####################################
+
+App				= colorecho
+DebugFlag		= 1
+AppsDir			= :Apps_Data:
+ObjectDir		= :Objects:
+CC				= armcc
+LINK			= armlink
+WorkingDisk		=
+
+#####################################
+#	Default compiler options
+#####################################
+
+COptions			= -fa -zps0 -za1
+CDebugOptions		= -g -d DEBUG={DebugFlag}
+LOptions			= -aif -r -b 0x00
+LStackSize			= 4096
+LDebugOptions		= -d
+ModbinDebugOptions	= -debug
+
+#####################################
+#	Object files
+#####################################
+
+OBJECTS			=	 {ObjectDir}colorecho.c.o {ObjectDir}colorecho_tools.c.o "{3DOLibs}"cstartup.o
+
+LIBS			=	 âˆ‚
+					"{3DOLibs}Lib3DO.lib" âˆ‚
+					"{3DOLibs}music.lib" âˆ‚
+					"{3DOLibs}audio.lib" âˆ‚
+					"{3DOLibs}operamath.lib" âˆ‚
+					"{3DOLibs}graphics.lib" âˆ‚
+					"{3DOLibs}input.lib" âˆ‚
+					"{3DOLibs}clib.lib"
+
+#####################################
+#	Default build rules
+#####################################
+
+All				Æ’	{App}
+
+{ObjectDir}		Æ’	:
+
+.c.o	Æ’	.c
+	{CC} -i "{3DOIncludes}" {COptions} {CDebugOptions} -o {TargDir}{Default}.c.o {DepDir}{Default}.c
+
+#####################################
+#	Target build rules
+#####################################
+
+{App} Æ’ {App}.make {OBJECTS}
+	{LINK} {LOptions} {LDebugOptions} âˆ‚
+		{OBJECTS} âˆ‚
+		{LIBS} âˆ‚
+		-o "{WorkingDisk}"{Targ}
+	SetFile "{WorkingDisk}"{Targ} -c 'EaDJ' -t PROJ
+	modbin "{WorkingDisk}"{Targ} -stack {LStackSize} {ModbinDebugOptions}
+	stripaif "{WorkingDisk}"{Targ} -o {Targ} -s {Targ}.sym
+	if not `exists "{AppsDir}"`
+		newFolder "{AppsDir}"
+	end
+	move -y {Targ} "{AppsDir}"
+	move -y {Targ}.sym "{AppsDir}"
+
+#####################################
+#	Additional Target Dependencies
+#####################################
+
+{ObjectDir}colorecho.c.o			Æ’	{App}.make
+{ObjectDir}colorecho_tools.c.o			Æ’	{App}.make

--- a/release/examples/Graphics/Performance_Test/perftest.make
+++ b/release/examples/Graphics/Performance_Test/perftest.make
@@ -1,1 +1,87 @@
-######################################### Copyright (C) 1995, an unpublished work by The 3DO Company. All rights reserved.## This material contains confidential information that is the property of The 3DO Company.## Any unauthorized duplication, disclosure or use is prohibited.## $Id: perftest.make,v 1.6 1995/01/19 02:04:37 mattm Exp $########################################   File:       perftest.make#   Target:     perftest#   Sources:    perftest.c sprite.c##   Copyright (c) 1995, The 3DO Company#   All rights reserved.#######################################	Symbol definitions#####################################App				= perftestDebugFlag		= 1SourceDir		= {3DOFolder}:Examples:Graphics:Performance_Test:ObjectDir		= :Objects:Apps_Data		= :Apps_Data:CC				= armccLINK			= armlinkWorkingDisk		=3DOAutoDup		= -y######################################	Default compiler options#####################################COptions			= -fa -zps0 -za1CDebugOptions		= -g -d DEBUG={DebugFlag}LOptions			= -aif -r -b 0x00LStackSize			= 4096LDebugOptions		= -dModbinDebugOptions	= -debug######################################	Object files#####################################OBJECTS			=	 {ObjectDir}perftest.c.o {ObjectDir}sprite.c.o "{3DOLibs}"cstartup.oLIBS			=	"{3DOFolder}Examples:ExamplesLib:exampleslib.lib" ¶					"{3DOLibs}lib3do.lib" 		¶					"{3DOLibs}audio.lib" 		¶					"{3DOLibs}operamath.lib" 	¶					"{3DOLibs}graphics.lib" 	¶					"{3DOLibs}input.lib" 		¶					"{3DOLibs}clib.lib"######################################	Default build rules#####################################All				Ä	{App}{ObjectDir}		Ä	:.c.o	Ä	.c	{CC} -i "{3DOIncludes}" -i "{3DOFolder}Examples:ExamplesLib:"  {COptions} {CDebugOptions} -o {TargDir}{Default}.c.o {DepDir}{Default}.c######################################	Target build rules#####################################{App} Ä {App}.make {OBJECTS}	{LINK} {LOptions} {LDebugOptions} ¶		{OBJECTS} ¶		{LIBS} ¶		-o "{WorkingDisk}"{Targ}	SetFile "{WorkingDisk}"{Targ} -c 'EaDJ' -t 'PROJ'	modbin "{WorkingDisk}"{Targ} -stack {LStackSize} {ModbinDebugOptions}	stripaif "{WorkingDisk}"{Targ} -o {Targ} -s {Targ}.sym	move {3DOAutodup} {Targ} "{Apps_Data}"	move {3DOAutodup} {Targ}.sym "{Apps_Data}"######################################	Additional Target Dependencies#####################################{ObjectDir}perftest.c.o			Ä	{App}.make{ObjectDir}sprite.c.o			Ä	{App}.make
+#####################################
+##
+## Copyright (C) 1995, an unpublished work by The 3DO Company. All rights reserved.
+## This material contains confidential information that is the property of The 3DO Company.
+## Any unauthorized duplication, disclosure or use is prohibited.
+## $Id: perftest.make,v 1.6 1995/01/19 02:04:37 mattm Exp $
+##
+#####################################
+#   File:       perftest.make
+#   Target:     perftest
+#   Sources:    perftest.c sprite.c
+#
+#   Copyright (c) 1995, The 3DO Company
+#   All rights reserved.
+#
+
+#####################################
+#	Symbol definitions
+#####################################
+
+App				= perftest
+DebugFlag		= 1
+SourceDir		= {3DOFolder}:Examples:Graphics:Performance_Test:
+ObjectDir		= :Objects:
+Apps_Data		= :Apps_Data:
+CC				= armcc
+LINK			= armlink
+WorkingDisk		=
+3DOAutoDup		= -y
+
+#####################################
+#	Default compiler options
+#####################################
+
+COptions			= -fa -zps0 -za1
+CDebugOptions		= -g -d DEBUG={DebugFlag}
+LOptions			= -aif -r -b 0x00
+LStackSize			= 4096
+LDebugOptions		= -d
+ModbinDebugOptions	= -debug
+
+#####################################
+#	Object files
+#####################################
+
+OBJECTS			=	 {ObjectDir}perftest.c.o {ObjectDir}sprite.c.o "{3DOLibs}"cstartup.o
+
+LIBS			=	"{3DOFolder}Examples:ExamplesLib:exampleslib.lib" âˆ‚
+					"{3DOLibs}lib3do.lib" 		âˆ‚
+					"{3DOLibs}audio.lib" 		âˆ‚
+					"{3DOLibs}operamath.lib" 	âˆ‚
+					"{3DOLibs}graphics.lib" 	âˆ‚
+					"{3DOLibs}input.lib" 		âˆ‚
+					"{3DOLibs}clib.lib"
+
+#####################################
+#	Default build rules
+#####################################
+
+All				Æ’	{App}
+
+{ObjectDir}		Æ’	:
+
+.c.o	Æ’	.c
+	{CC} -i "{3DOIncludes}" -i "{3DOFolder}Examples:ExamplesLib:"  {COptions} {CDebugOptions} -o {TargDir}{Default}.c.o {DepDir}{Default}.c
+
+#####################################
+#	Target build rules
+#####################################
+
+{App} Æ’ {App}.make {OBJECTS}
+	{LINK} {LOptions} {LDebugOptions} âˆ‚
+		{OBJECTS} âˆ‚
+		{LIBS} âˆ‚
+		-o "{WorkingDisk}"{Targ}
+	SetFile "{WorkingDisk}"{Targ} -c 'EaDJ' -t 'PROJ'
+	modbin "{WorkingDisk}"{Targ} -stack {LStackSize} {ModbinDebugOptions}
+	stripaif "{WorkingDisk}"{Targ} -o {Targ} -s {Targ}.sym
+	move {3DOAutodup} {Targ} "{Apps_Data}"
+	move {3DOAutodup} {Targ}.sym "{Apps_Data}"
+
+#####################################
+#	Additional Target Dependencies
+#####################################
+
+{ObjectDir}perftest.c.o			Æ’	{App}.make
+{ObjectDir}sprite.c.o			Æ’	{App}.make

--- a/release/examples/Graphics/Slideshow/animationvdl.make
+++ b/release/examples/Graphics/Slideshow/animationvdl.make
@@ -1,1 +1,94 @@
-######################################### Copyright (C) 1995, an unpublished work by The 3DO Company. All rights reserved.## This material contains confidential information that is the property of The 3DO Company.## Any unauthorized duplication, disclosure or use is prohibited.## $Id: animationvdl.make,v 1.8 1995/01/20 04:55:01 ceckhaus Exp $########################################   File:       animationvdl.make#   Target:     animationvdl#   Sources:    animationvdl.c#######################################		Symbol definitions#####################################App				=	animationvdlDebugFlag		=	1ObjectDir		=	:Objects:SourceDir		=	:AppsDir			=	:Apps_Data:ExamplesLibDir	=	{3DOFolder}Examples:ExamplesLib:CC				=	armccLINK			=	armlinkWorkingDisk		= ######################################	Default compiler options#####################################COptions			= -fa -zps0 -za1 -i "{ExamplesLibDir}"CDebugOptions		= -g -d DEBUG={DebugFlag}LOptions			= -aif -r -b 0x00LStackSize			= 4096LDebugOptions		= -dModbinDebugOptions	= -debug######################################		Object files#####################################OBJECTS			=	{ObjectDir}{App}.c.o ¶					"{3DOLibs}"cstartup.oLIBS			=	¶					"{ExamplesLibDir}ExamplesLib.lib"  ¶					"{3DOLibs}Lib3DO.lib" ¶					"{3DOLibs}audio.lib" ¶					"{3DOLibs}music.lib" ¶					"{3DOLibs}operamath.lib" ¶					"{3DOLibs}filesystem.lib" ¶					"{3DOLibs}graphics.lib" ¶					"{3DOLibs}input.lib" ¶					"{3DOLibs}clib.lib"					######################################	Default build rules#####################################All				Ä	{App}{ObjectDir}		Ä	:.c.o	Ä	.c	{CC} -i "{3DOIncludes}" {COptions} {CDebugOptions} -o {TargDir}{Default}.c.o {DepDir}{Default}.c######################################	Target build rules#####################################{App} Ä {App}.make {OBJECTS}	{LINK} {LOptions} {LDebugOptions} ¶		{OBJECTS} ¶		{LIBS} ¶		-o "{WorkingDisk}"{Targ}	SetFile "{WorkingDisk}"{Targ} -c 'EaDJ' -t 'PROJ'	modbin "{WorkingDisk}"{Targ} -stack {LStackSize} {ModbinDebugOptions}	stripaif "{WorkingDisk}"{Targ} -o {Targ} -s {Targ}.sym	if not `exists "{AppsDir}"`		newFolder "{AppsDir}"	end	move -y {Targ} "{AppsDir}"	move -y {Targ}.sym "{AppsDir}"######################################	Include file dependencies#####################################{ObjectDir}{App}.c.o			Ä	{App}.make
+
+#####################################
+##
+## Copyright (C) 1995, an unpublished work by The 3DO Company. All rights reserved.
+## This material contains confidential information that is the property of The 3DO Company.
+## Any unauthorized duplication, disclosure or use is prohibited.
+## $Id: animationvdl.make,v 1.8 1995/01/20 04:55:01 ceckhaus Exp $
+##
+#####################################
+
+#   File:       animationvdl.make
+#   Target:     animationvdl
+#   Sources:    animationvdl.c
+#
+
+#####################################
+#		Symbol definitions
+#####################################
+
+App				=	animationvdl
+DebugFlag		=	1
+ObjectDir		=	:Objects:
+SourceDir		=	:
+AppsDir			=	:Apps_Data:
+ExamplesLibDir	=	{3DOFolder}Examples:ExamplesLib:
+CC				=	armcc
+LINK			=	armlink
+WorkingDisk		= 
+
+#####################################
+#	Default compiler options
+#####################################
+
+COptions			= -fa -zps0 -za1 -i "{ExamplesLibDir}"
+CDebugOptions		= -g -d DEBUG={DebugFlag}
+LOptions			= -aif -r -b 0x00
+LStackSize			= 4096
+LDebugOptions		= -d
+ModbinDebugOptions	= -debug
+
+#####################################
+#		Object files
+#####################################
+
+OBJECTS			=	{ObjectDir}{App}.c.o âˆ‚
+					"{3DOLibs}"cstartup.o
+
+LIBS			=	âˆ‚
+					"{ExamplesLibDir}ExamplesLib.lib"  âˆ‚
+					"{3DOLibs}Lib3DO.lib" âˆ‚
+					"{3DOLibs}audio.lib" âˆ‚
+					"{3DOLibs}music.lib" âˆ‚
+					"{3DOLibs}operamath.lib" âˆ‚
+					"{3DOLibs}filesystem.lib" âˆ‚
+					"{3DOLibs}graphics.lib" âˆ‚
+					"{3DOLibs}input.lib" âˆ‚
+					"{3DOLibs}clib.lib"
+					
+#####################################
+#	Default build rules
+#####################################
+
+All				Æ’	{App}
+
+{ObjectDir}		Æ’	:
+
+.c.o	Æ’	.c
+	{CC} -i "{3DOIncludes}" {COptions} {CDebugOptions} -o {TargDir}{Default}.c.o {DepDir}{Default}.c
+
+#####################################
+#	Target build rules
+#####################################
+
+{App} Æ’ {App}.make {OBJECTS}
+	{LINK} {LOptions} {LDebugOptions} âˆ‚
+		{OBJECTS} âˆ‚
+		{LIBS} âˆ‚
+		-o "{WorkingDisk}"{Targ}
+	SetFile "{WorkingDisk}"{Targ} -c 'EaDJ' -t 'PROJ'
+	modbin "{WorkingDisk}"{Targ} -stack {LStackSize} {ModbinDebugOptions}
+	stripaif "{WorkingDisk}"{Targ} -o {Targ} -s {Targ}.sym
+	if not `exists "{AppsDir}"`
+		newFolder "{AppsDir}"
+	end
+	move -y {Targ} "{AppsDir}"
+	move -y {Targ}.sym "{AppsDir}"
+
+#####################################
+#	Include file dependencies
+#####################################
+
+{ObjectDir}{App}.c.o			Æ’	{App}.make
+
+

--- a/release/examples/Graphics/Slideshow/slideshow.make
+++ b/release/examples/Graphics/Slideshow/slideshow.make
@@ -1,1 +1,92 @@
-######################################### Copyright (C) 1995, an unpublished work by The 3DO Company. All rights reserved.## This material contains confidential information that is the property of The 3DO Company.## Any unauthorized duplication, disclosure or use is prohibited.## $Id: slideshow.make,v 1.7 1995/01/20 04:55:01 ceckhaus Exp $########################################   File:       slideshow.make#   Target:     slideshow#   Sources:    slideshow.c#######################################	Symbol definitions#####################################App				= slideshowDebugFlag		= 1ObjectDir		= :Objects:SourceDir		= :AppsDir			= :Apps_Data:ExamplesLibDir	= {3DOFolder}Examples:ExamplesLib:CC				= armccLINK			= armlinkWorkingDisk		= ######################################	Default compiler options#####################################COptions			= -fa -zps0 -za1 -i "{ExamplesLibDir}"CDebugOptions		= -g -d DEBUG={DebugFlag}LOptions			= -aif -r -b 0x00LStackSize			= 4096LDebugOptions		= -dModbinDebugOptions	= -debug######################################	Object files#####################################OBJECTS			=	{ObjectDir}{App}.c.o ¶					"{3DOLibs}"cstartup.oLIBS			=	¶					"{ExamplesLibDir}ExamplesLib.lib"  ¶					"{3DOLibs}Lib3DO.lib" ¶					"{3DOLibs}audio.lib" ¶					"{3DOLibs}music.lib" ¶					"{3DOLibs}operamath.lib" ¶					"{3DOLibs}filesystem.lib" ¶					"{3DOLibs}graphics.lib" ¶					"{3DOLibs}input.lib" ¶					"{3DOLibs}clib.lib"					######################################	Default build rules#####################################All				Ä	{App}{ObjectDir}		Ä	:.c.o	Ä	.c	{CC} -i "{3DOIncludes}" {COptions} {CDebugOptions} -o {TargDir}{Default}.c.o {DepDir}{Default}.c######################################	Target build rules#####################################{App} Ä {App}.make {OBJECTS}	{LINK} {LOptions} {LDebugOptions} ¶		{OBJECTS} ¶		{LIBS} ¶		-o "{WorkingDisk}"{Targ}	SetFile "{WorkingDisk}"{Targ} -c 'EaDJ' -t 'PROJ'	modbin "{WorkingDisk}"{Targ} -stack {LStackSize} {ModbinDebugOptions}	stripaif "{WorkingDisk}"{Targ} -o {Targ} -s {Targ}.sym	if not `exists "{AppsDir}"`		newFolder "{AppsDir}"	end	move -y {Targ} "{AppsDir}"	move -y {Targ}.sym "{AppsDir}"######################################	Additional Target Dependencies#####################################{ObjectDir}{App}.c.o		Ä	{App}.make {App}.h
+
+#####################################
+##
+## Copyright (C) 1995, an unpublished work by The 3DO Company. All rights reserved.
+## This material contains confidential information that is the property of The 3DO Company.
+## Any unauthorized duplication, disclosure or use is prohibited.
+## $Id: slideshow.make,v 1.7 1995/01/20 04:55:01 ceckhaus Exp $
+##
+#####################################
+
+#   File:       slideshow.make
+#   Target:     slideshow
+#   Sources:    slideshow.c
+#
+
+#####################################
+#	Symbol definitions
+#####################################
+
+App				= slideshow
+DebugFlag		= 1
+ObjectDir		= :Objects:
+SourceDir		= :
+AppsDir			= :Apps_Data:
+ExamplesLibDir	= {3DOFolder}Examples:ExamplesLib:
+CC				= armcc
+LINK			= armlink
+WorkingDisk		= 
+
+#####################################
+#	Default compiler options
+#####################################
+
+COptions			= -fa -zps0 -za1 -i "{ExamplesLibDir}"
+CDebugOptions		= -g -d DEBUG={DebugFlag}
+LOptions			= -aif -r -b 0x00
+LStackSize			= 4096
+LDebugOptions		= -d
+ModbinDebugOptions	= -debug
+
+#####################################
+#	Object files
+#####################################
+
+OBJECTS			=	{ObjectDir}{App}.c.o âˆ‚
+					"{3DOLibs}"cstartup.o
+
+LIBS			=	âˆ‚
+					"{ExamplesLibDir}ExamplesLib.lib"  âˆ‚
+					"{3DOLibs}Lib3DO.lib" âˆ‚
+					"{3DOLibs}audio.lib" âˆ‚
+					"{3DOLibs}music.lib" âˆ‚
+					"{3DOLibs}operamath.lib" âˆ‚
+					"{3DOLibs}filesystem.lib" âˆ‚
+					"{3DOLibs}graphics.lib" âˆ‚
+					"{3DOLibs}input.lib" âˆ‚
+					"{3DOLibs}clib.lib"
+					
+#####################################
+#	Default build rules
+#####################################
+
+All				Æ’	{App}
+
+{ObjectDir}		Æ’	:
+
+.c.o	Æ’	.c
+	{CC} -i "{3DOIncludes}" {COptions} {CDebugOptions} -o {TargDir}{Default}.c.o {DepDir}{Default}.c
+
+#####################################
+#	Target build rules
+#####################################
+
+{App} Æ’ {App}.make {OBJECTS}
+	{LINK} {LOptions} {LDebugOptions} âˆ‚
+		{OBJECTS} âˆ‚
+		{LIBS} âˆ‚
+		-o "{WorkingDisk}"{Targ}
+	SetFile "{WorkingDisk}"{Targ} -c 'EaDJ' -t 'PROJ'
+	modbin "{WorkingDisk}"{Targ} -stack {LStackSize} {ModbinDebugOptions}
+	stripaif "{WorkingDisk}"{Targ} -o {Targ} -s {Targ}.sym
+	if not `exists "{AppsDir}"`
+		newFolder "{AppsDir}"
+	end
+	move -y {Targ} "{AppsDir}"
+	move -y {Targ}.sym "{AppsDir}"
+
+#####################################
+#	Additional Target Dependencies
+#####################################
+
+{ObjectDir}{App}.c.o		Æ’	{App}.make {App}.h

--- a/release/examples/Graphics/Slideshow_24bit/slideshow24.make
+++ b/release/examples/Graphics/Slideshow_24bit/slideshow24.make
@@ -1,1 +1,96 @@
-######################################### Copyright (C) 1995, an unpublished work by The 3DO Company. All rights reserved.## This material contains confidential information that is the property of The 3DO Company.## Any unauthorized duplication, disclosure or use is prohibited.## $Id: slideshow24.make,v 1.8 1995/01/20 04:55:50 ceckhaus Exp $########################################   File:       slideshow24.make#   Target:     slideshow24#   Sources:    slideshow24.c loadfile24.c vdl24util.c#######################################	Symbol definitions#####################################App				= slideshow24DebugFlag		= 1ObjectDir		= :Objects:SourceDir		= :AppsDir			= :Apps_Data:ExamplesLibDir	= {3DOFolder}Examples:ExamplesLib:CC				= armccLINK			= armlinkWorkingDisk		= ######################################	Default compiler options#####################################COptions			= -fa -zps0 -za1 -i "{ExamplesLibDir}"CDebugOptions		= -g -d DEBUG={DebugFlag}LOptions			= -aif -r -b 0x00LStackSize			= 4096LDebugOptions		= -dModbinDebugOptions	= -debug######################################	Object files#####################################OBJECTS			=	{ObjectDir}loadfile24.c.o ¶					{ObjectDir}vdl24util.c.o ¶					{ObjectDir}{App}.c.o ¶					"{3DOLibs}"cstartup.oLIBS			=	¶					"{ExamplesLibDir}ExamplesLib.lib"  ¶					"{3DOLibs}Lib3DO.lib" ¶					"{3DOLibs}audio.lib" ¶					"{3DOLibs}music.lib" ¶					"{3DOLibs}operamath.lib" ¶					"{3DOLibs}filesystem.lib" ¶					"{3DOLibs}graphics.lib" ¶					"{3DOLibs}input.lib" ¶					"{3DOLibs}clib.lib"######################################	Default build rules#####################################All				Ä	{App}{ObjectDir}		Ä	:.c.o	Ä	.c	{CC} -i "{3DOIncludes}" {COptions} {CDebugOptions} -o {TargDir}{Default}.c.o {DepDir}{Default}.c######################################	Target build rules#####################################{App} Ä {App}.make {OBJECTS}	{LINK} {LOptions} {LDebugOptions} ¶		{OBJECTS} ¶		{LIBS} ¶		-o "{WorkingDisk}"{Targ}	SetFile "{WorkingDisk}"{Targ} -c 'EaDJ' -t 'PROJ'	modbin "{WorkingDisk}"{Targ} -stack {LStackSize} {ModbinDebugOptions}	stripaif "{WorkingDisk}"{Targ} -o {Targ} -s {Targ}.sym	if not `exists "{AppsDir}"`		newFolder "{AppsDir}"	end	move -y {Targ} "{AppsDir}"	move -y {Targ}.sym "{AppsDir}"######################################	Additional Target Dependencies#####################################{ObjectDir}{App}.c.o			Ä	{App}.make {App}.h loadfile24.h vdl24util.h{ObjectDir}loadfile24.c.o		Ä	{App}.make loadfile24.h{ObjectDir}vdl24util.c.o		Ä	{App}.make vdl24util.h
+
+#####################################
+##
+## Copyright (C) 1995, an unpublished work by The 3DO Company. All rights reserved.
+## This material contains confidential information that is the property of The 3DO Company.
+## Any unauthorized duplication, disclosure or use is prohibited.
+## $Id: slideshow24.make,v 1.8 1995/01/20 04:55:50 ceckhaus Exp $
+##
+#####################################
+
+#   File:       slideshow24.make
+#   Target:     slideshow24
+#   Sources:    slideshow24.c loadfile24.c vdl24util.c
+#
+
+#####################################
+#	Symbol definitions
+#####################################
+
+App				= slideshow24
+DebugFlag		= 1
+ObjectDir		= :Objects:
+SourceDir		= :
+AppsDir			= :Apps_Data:
+ExamplesLibDir	= {3DOFolder}Examples:ExamplesLib:
+CC				= armcc
+LINK			= armlink
+WorkingDisk		= 
+
+#####################################
+#	Default compiler options
+#####################################
+
+COptions			= -fa -zps0 -za1 -i "{ExamplesLibDir}"
+CDebugOptions		= -g -d DEBUG={DebugFlag}
+LOptions			= -aif -r -b 0x00
+LStackSize			= 4096
+LDebugOptions		= -d
+ModbinDebugOptions	= -debug
+
+#####################################
+#	Object files
+#####################################
+
+OBJECTS			=	{ObjectDir}loadfile24.c.o âˆ‚
+					{ObjectDir}vdl24util.c.o âˆ‚
+					{ObjectDir}{App}.c.o âˆ‚
+					"{3DOLibs}"cstartup.o
+
+LIBS			=	âˆ‚
+					"{ExamplesLibDir}ExamplesLib.lib"  âˆ‚
+					"{3DOLibs}Lib3DO.lib" âˆ‚
+					"{3DOLibs}audio.lib" âˆ‚
+					"{3DOLibs}music.lib" âˆ‚
+					"{3DOLibs}operamath.lib" âˆ‚
+					"{3DOLibs}filesystem.lib" âˆ‚
+					"{3DOLibs}graphics.lib" âˆ‚
+					"{3DOLibs}input.lib" âˆ‚
+					"{3DOLibs}clib.lib"
+
+#####################################
+#	Default build rules
+#####################################
+
+All				Æ’	{App}
+
+{ObjectDir}		Æ’	:
+
+.c.o	Æ’	.c
+	{CC} -i "{3DOIncludes}" {COptions} {CDebugOptions} -o {TargDir}{Default}.c.o {DepDir}{Default}.c
+
+#####################################
+#	Target build rules
+#####################################
+
+{App} Æ’ {App}.make {OBJECTS}
+	{LINK} {LOptions} {LDebugOptions} âˆ‚
+		{OBJECTS} âˆ‚
+		{LIBS} âˆ‚
+		-o "{WorkingDisk}"{Targ}
+	SetFile "{WorkingDisk}"{Targ} -c 'EaDJ' -t 'PROJ'
+	modbin "{WorkingDisk}"{Targ} -stack {LStackSize} {ModbinDebugOptions}
+	stripaif "{WorkingDisk}"{Targ} -o {Targ} -s {Targ}.sym
+	if not `exists "{AppsDir}"`
+		newFolder "{AppsDir}"
+	end
+	move -y {Targ} "{AppsDir}"
+	move -y {Targ}.sym "{AppsDir}"
+
+#####################################
+#	Additional Target Dependencies
+#####################################
+
+{ObjectDir}{App}.c.o			Æ’	{App}.make {App}.h loadfile24.h vdl24util.h
+{ObjectDir}loadfile24.c.o		Æ’	{App}.make loadfile24.h
+{ObjectDir}vdl24util.c.o		Æ’	{App}.make vdl24util.h

--- a/release/examples/Graphics/aaplayer/aaplayer.make
+++ b/release/examples/Graphics/aaplayer/aaplayer.make
@@ -1,1 +1,87 @@
-######################################### Copyright (C) 1995, an unpublished work by The 3DO Company. All rights reserved.## This material contains confidential information that is the property of The 3DO Company.## Any unauthorized duplication, disclosure or use is prohibited.## $Id: aaplayer.make,v 1.9 1995/01/16 19:45:23 gyld Exp $#############################################################################	Symbol definitions#####################################App				= aaplayerDebugFlag		= 1ObjectDir		= :Objects:SourceDir		= :AppsDir			= :Apps_Data:ExampleLibDir			= {3DOFolder}Examples:ExamplesLib:CC				= armccLINK			= armlinkWorkingDisk		=######################################	Default compiler options#####################################COptions			= -fa -zps0 -za1 -i "{ExampleLibDir}"CDebugOptions		= -g -d DEBUG={DebugFlag}LOptions			= -aif -r -b 0x00LStackSize			= 4096LDebugOptions		= -dModbinDebugOptions	= -debug######################################	Object files#####################################OBJECTS			=	 {ObjectDir}aaplayer.c.o "{3DOLibs}"cstartup.oLIBS			=	 ¶					"{ExampleLibDir}ExamplesLib.lib"  ¶					"{3DOLibs}Lib3DO.lib" ¶					"{3DOLibs}audio.lib" ¶					"{3DOLibs}music.lib" ¶					"{3DOLibs}operamath.lib" ¶					"{3DOLibs}filesystem.lib" ¶					"{3DOLibs}graphics.lib" ¶					"{3DOLibs}input.lib" ¶					"{3DOLibs}clib.lib"######################################	Default build rules#####################################All				Ä	{App}{ObjectDir}		Ä	:.c.o	Ä	.c	{CC} -i "{3DOIncludes}" {COptions} {CDebugOptions} -o {TargDir}{Default}.c.o {DepDir}{Default}.c######################################	Target build rules#####################################{App} Ä {App}.make {OBJECTS}	{LINK} {LOptions} {LDebugOptions} ¶		{OBJECTS} ¶		{LIBS} ¶		-o "{WorkingDisk}"{Targ}	SetFile "{WorkingDisk}"{Targ} -c 'EaDJ' -t PROJ	modbin "{WorkingDisk}"{Targ} -stack {LStackSize} {ModbinDebugOptions}	stripaif "{WorkingDisk}"{Targ} -o {Targ} -s {Targ}.sym	if not `exists "{AppsDir}"`		newFolder "{AppsDir}"	end	move -y {Targ} "{AppsDir}"	move -y {Targ}.sym "{AppsDir}"######################################	Additional Target Dependencies#####################################{ObjectDir}aaplayer.c.o			Ä	{App}.make "{SourceDir}"aaplayer.h "{SourceDir}"aaerror.h
+#####################################
+##
+## Copyright (C) 1995, an unpublished work by The 3DO Company. All rights reserved.
+## This material contains confidential information that is the property of The 3DO Company.
+## Any unauthorized duplication, disclosure or use is prohibited.
+## $Id: aaplayer.make,v 1.9 1995/01/16 19:45:23 gyld Exp $
+##
+#####################################
+
+#####################################
+#	Symbol definitions
+#####################################
+
+App				= aaplayer
+DebugFlag		= 1
+ObjectDir		= :Objects:
+SourceDir		= :
+AppsDir			= :Apps_Data:
+ExampleLibDir			= {3DOFolder}Examples:ExamplesLib:
+CC				= armcc
+LINK			= armlink
+WorkingDisk		=
+
+#####################################
+#	Default compiler options
+#####################################
+
+COptions			= -fa -zps0 -za1 -i "{ExampleLibDir}"
+CDebugOptions		= -g -d DEBUG={DebugFlag}
+LOptions			= -aif -r -b 0x00
+LStackSize			= 4096
+LDebugOptions		= -d
+ModbinDebugOptions	= -debug
+
+#####################################
+#	Object files
+#####################################
+
+OBJECTS			=	 {ObjectDir}aaplayer.c.o "{3DOLibs}"cstartup.o
+
+LIBS			=	 âˆ‚
+					"{ExampleLibDir}ExamplesLib.lib"  âˆ‚
+					"{3DOLibs}Lib3DO.lib" âˆ‚
+					"{3DOLibs}audio.lib" âˆ‚
+					"{3DOLibs}music.lib" âˆ‚
+					"{3DOLibs}operamath.lib" âˆ‚
+					"{3DOLibs}filesystem.lib" âˆ‚
+					"{3DOLibs}graphics.lib" âˆ‚
+					"{3DOLibs}input.lib" âˆ‚
+					"{3DOLibs}clib.lib"
+
+#####################################
+#	Default build rules
+#####################################
+
+All				Æ’	{App}
+
+{ObjectDir}		Æ’	:
+
+.c.o	Æ’	.c
+	{CC} -i "{3DOIncludes}" {COptions} {CDebugOptions} -o {TargDir}{Default}.c.o {DepDir}{Default}.c
+
+#####################################
+#	Target build rules
+#####################################
+
+{App} Æ’ {App}.make {OBJECTS}
+	{LINK} {LOptions} {LDebugOptions} âˆ‚
+		{OBJECTS} âˆ‚
+		{LIBS} âˆ‚
+		-o "{WorkingDisk}"{Targ}
+	SetFile "{WorkingDisk}"{Targ} -c 'EaDJ' -t PROJ
+	modbin "{WorkingDisk}"{Targ} -stack {LStackSize} {ModbinDebugOptions}
+	stripaif "{WorkingDisk}"{Targ} -o {Targ} -s {Targ}.sym
+	if not `exists "{AppsDir}"`
+		newFolder "{AppsDir}"
+	end
+	move -y {Targ} "{AppsDir}"
+	move -y {Targ}.sym "{AppsDir}"
+
+
+#####################################
+#	Additional Target Dependencies
+#####################################
+
+{ObjectDir}aaplayer.c.o			Æ’	{App}.make "{SourceDir}"aaplayer.h "{SourceDir}"aaerror.h
+

--- a/release/examples/Graphics/lrex/lrex.make
+++ b/release/examples/Graphics/lrex/lrex.make
@@ -1,1 +1,87 @@
-######################################### Copyright (C) 1995, an unpublished work by The 3DO Company. All rights reserved.## This material contains confidential information that is the property of The 3DO Company.## Any unauthorized duplication, disclosure or use is prohibited.## $Id: lrex.make,v 1.9 1995/01/16 19:47:04 gyld Exp $#############################################################################	Symbol definitions#####################################App				= lrexDebugFlag		= 1ObjectDir		= :Objects:SourceDir		= :AppsDir			= :Apps_Data:ExampleLibDir			= {3DOFolder}Examples:ExamplesLib:CC				= armccLINK			= armlinkWorkingDisk		=######################################	Default compiler options#####################################COptions			= -fa -zps0 -za1 -i "{ExampleLibDir}"CDebugOptions		= -g -d DEBUG={DebugFlag}LOptions			= -aif -r -b 0x00LStackSize			= 4096LDebugOptions		= -dModbinDebugOptions	= -debug######################################	Object files#####################################OBJECTS			=	 {ObjectDir}lrex.c.o "{3DOLibs}"cstartup.oLIBS			=	 ¶					"{ExampleLibDir}ExamplesLib.lib"  ¶					"{3DOLibs}Lib3DO.lib" ¶					"{3DOLibs}audio.lib" ¶					"{3DOLibs}music.lib" ¶					"{3DOLibs}operamath.lib" ¶					"{3DOLibs}filesystem.lib" ¶					"{3DOLibs}graphics.lib" ¶					"{3DOLibs}input.lib" ¶					"{3DOLibs}clib.lib"######################################	Default build rules#####################################All				Ä	{App}{ObjectDir}		Ä	:.c.o	Ä	.c	{CC} -i "{3DOIncludes}" {COptions} {CDebugOptions} -o {TargDir}{Default}.c.o {DepDir}{Default}.c######################################	Target build rules#####################################{App} Ä {App}.make {OBJECTS}	{LINK} {LOptions} {LDebugOptions} ¶		{OBJECTS} ¶		{LIBS} ¶		-o "{WorkingDisk}"{Targ}	SetFile "{WorkingDisk}"{Targ} -c 'EaDJ' -t PROJ	modbin "{WorkingDisk}"{Targ} -stack {LStackSize} {ModbinDebugOptions}	stripaif "{WorkingDisk}"{Targ} -o {Targ} -s {Targ}.sym	if not `exists "{AppsDir}"`		newFolder "{AppsDir}"	end	move -y {Targ} "{AppsDir}"	move -y {Targ}.sym "{AppsDir}"######################################	Additional Target Dependencies#####################################{ObjectDir}lrex.c.o			Ä	{App}.make "{SourceDir}"lrex.h "{SourceDir}"lrexerror.h
+#####################################
+##
+## Copyright (C) 1995, an unpublished work by The 3DO Company. All rights reserved.
+## This material contains confidential information that is the property of The 3DO Company.
+## Any unauthorized duplication, disclosure or use is prohibited.
+## $Id: lrex.make,v 1.9 1995/01/16 19:47:04 gyld Exp $
+##
+#####################################
+
+#####################################
+#	Symbol definitions
+#####################################
+
+App				= lrex
+DebugFlag		= 1
+ObjectDir		= :Objects:
+SourceDir		= :
+AppsDir			= :Apps_Data:
+ExampleLibDir			= {3DOFolder}Examples:ExamplesLib:
+CC				= armcc
+LINK			= armlink
+WorkingDisk		=
+
+#####################################
+#	Default compiler options
+#####################################
+
+COptions			= -fa -zps0 -za1 -i "{ExampleLibDir}"
+CDebugOptions		= -g -d DEBUG={DebugFlag}
+LOptions			= -aif -r -b 0x00
+LStackSize			= 4096
+LDebugOptions		= -d
+ModbinDebugOptions	= -debug
+
+#####################################
+#	Object files
+#####################################
+
+OBJECTS			=	 {ObjectDir}lrex.c.o "{3DOLibs}"cstartup.o
+
+LIBS			=	 âˆ‚
+					"{ExampleLibDir}ExamplesLib.lib"  âˆ‚
+					"{3DOLibs}Lib3DO.lib" âˆ‚
+					"{3DOLibs}audio.lib" âˆ‚
+					"{3DOLibs}music.lib" âˆ‚
+					"{3DOLibs}operamath.lib" âˆ‚
+					"{3DOLibs}filesystem.lib" âˆ‚
+					"{3DOLibs}graphics.lib" âˆ‚
+					"{3DOLibs}input.lib" âˆ‚
+					"{3DOLibs}clib.lib"
+
+#####################################
+#	Default build rules
+#####################################
+
+All				Æ’	{App}
+
+{ObjectDir}		Æ’	:
+
+.c.o	Æ’	.c
+	{CC} -i "{3DOIncludes}" {COptions} {CDebugOptions} -o {TargDir}{Default}.c.o {DepDir}{Default}.c
+
+#####################################
+#	Target build rules
+#####################################
+
+{App} Æ’ {App}.make {OBJECTS}
+	{LINK} {LOptions} {LDebugOptions} âˆ‚
+		{OBJECTS} âˆ‚
+		{LIBS} âˆ‚
+		-o "{WorkingDisk}"{Targ}
+	SetFile "{WorkingDisk}"{Targ} -c 'EaDJ' -t PROJ
+	modbin "{WorkingDisk}"{Targ} -stack {LStackSize} {ModbinDebugOptions}
+	stripaif "{WorkingDisk}"{Targ} -o {Targ} -s {Targ}.sym
+	if not `exists "{AppsDir}"`
+		newFolder "{AppsDir}"
+	end
+	move -y {Targ} "{AppsDir}"
+	move -y {Targ}.sym "{AppsDir}"
+
+
+#####################################
+#	Additional Target Dependencies
+#####################################
+
+{ObjectDir}lrex.c.o			Æ’	{App}.make "{SourceDir}"lrex.h "{SourceDir}"lrexerror.h
+

--- a/release/examples/Graphics/symanim/symanim.make
+++ b/release/examples/Graphics/symanim/symanim.make
@@ -1,1 +1,94 @@
-######################################### Copyright (C) 1995, an unpublished work by The 3DO Company. All rights reserved.## This material contains confidential information that is the property of The 3DO Company.## Any unauthorized duplication, disclosure or use is prohibited.## $Id: symanim.make,v 1.5 1995/01/16 19:47:42 gyld Exp $#############################################################################		Symbol definitions#####################################Application		=	symanimDebugFlag		=	1AppsDir			= 	:Apps_Data:ObjectDir		=	:Objects:CC				=	armccASM				=	armasmLINK			=	armlink######################################	Default compiler options###################################### USE THE FOLLOWING LINE FOR SYMBOLIC DEBUGGINGCDebugOptions	= -g# USE THE FOLLOWING LINE FOR OPTIMIZED CODE#CDebugOptions	=COptions		= {CDebugOptions} -zps0 -za1 -i "{3DOIncludes}" -d DEBUG={DebugFlag}SOptions		= -bi -g -i "{3DOIncludes}"# USE THE FOLLOWING LINE FOR SYMBOLIC DEBUGGINGLDebugOptions	= -d		# turn on symbolic information# USE THE FOLLOWING LINE FOR OPTIMIZED CODE#LDebugOptions	=			# turn off symbolic informationLOptions		= {LDebugOptions} -aif -r -b 0x00 -workspace 4096######################################		Object files#####################################LIBS			=	"{3DOLibs}Lib3DO.lib"		¶					"{3DOLibs}operamath.lib"	¶					"{3DOLibs}graphics.lib"	¶					"{3DOLibs}filesystem.lib"	¶					"{3DOLibs}input.lib"		¶					"{3DOLibs}clib.lib"# NOTE: Add object files here...OBJECTS			=	"{ObjectDir}{Application}.c.o"¶					"{ObjectDir}Sprite.c.o"######################################	Default build rules#####################################All				Ä	{Application}{ObjectDir}		Ä	:.c.o			Ä	.c	{CC} {COptions} -o {TargDir}{Default}.c.o {DepDir}{Default}.c.s.o			Ä	.s	{ASM} {SOptions} -o {TargDir}{Default}.s.o {DepDir}{Default}.s######################################	Target build rules#####################################{Application}		ÄÄ	{Application}.make {LIBS} {OBJECTS}	{LINK}	{LOptions}					¶			-o {Application}				¶			"{3DOLibs}cstartup.o"		¶			{OBJECTS}					¶			{LIBS}	SetFile {Application} -c 'EaDJ' -t 'PROJ'	modbin {Application} -stack 0x2000 -debug	stripaif {Application} -o {Application}	if not `exists "{AppsDir}"`		newFolder "{AppsDir}"	end	move -y {Targ} "{AppsDir}"	move -y {Targ}.sym "{AppsDir}"######################################	Include file dependencies######################################{Application}.c		Ä	{Application}.hsymanim.c	Ä Sprite.hsprite.c Ä Sprite.h
+#####################################
+##
+## Copyright (C) 1995, an unpublished work by The 3DO Company. All rights reserved.
+## This material contains confidential information that is the property of The 3DO Company.
+## Any unauthorized duplication, disclosure or use is prohibited.
+## $Id: symanim.make,v 1.5 1995/01/16 19:47:42 gyld Exp $
+##
+#####################################
+
+#####################################
+#		Symbol definitions
+#####################################
+Application		=	symanim
+DebugFlag		=	1
+AppsDir			= 	:Apps_Data:
+ObjectDir		=	:Objects:
+CC				=	armcc
+ASM				=	armasm
+LINK			=	armlink
+
+
+#####################################
+#	Default compiler options
+#####################################
+# USE THE FOLLOWING LINE FOR SYMBOLIC DEBUGGING
+CDebugOptions	= -g
+# USE THE FOLLOWING LINE FOR OPTIMIZED CODE
+#CDebugOptions	=
+
+COptions		= {CDebugOptions} -zps0 -za1 -i "{3DOIncludes}" -d DEBUG={DebugFlag}
+
+SOptions		= -bi -g -i "{3DOIncludes}"
+
+# USE THE FOLLOWING LINE FOR SYMBOLIC DEBUGGING
+LDebugOptions	= -d		# turn on symbolic information
+# USE THE FOLLOWING LINE FOR OPTIMIZED CODE
+#LDebugOptions	=			# turn off symbolic information
+
+LOptions		= {LDebugOptions} -aif -r -b 0x00 -workspace 4096
+
+#####################################
+#		Object files
+#####################################
+LIBS			=	"{3DOLibs}Lib3DO.lib"		âˆ‚
+					"{3DOLibs}operamath.lib"	âˆ‚
+					"{3DOLibs}graphics.lib"	âˆ‚
+					"{3DOLibs}filesystem.lib"	âˆ‚
+					"{3DOLibs}input.lib"		âˆ‚
+					"{3DOLibs}clib.lib"
+
+# NOTE: Add object files here...
+OBJECTS			=	"{ObjectDir}{Application}.c.o"âˆ‚
+					"{ObjectDir}Sprite.c.o"
+
+#####################################
+#	Default build rules
+#####################################
+All				Æ’	{Application}
+
+{ObjectDir}		Æ’	:
+
+.c.o			Æ’	.c
+	{CC} {COptions} -o {TargDir}{Default}.c.o {DepDir}{Default}.c
+
+.s.o			Æ’	.s
+	{ASM} {SOptions} -o {TargDir}{Default}.s.o {DepDir}{Default}.s
+
+
+#####################################
+#	Target build rules
+#####################################
+{Application}		Æ’Æ’	{Application}.make {LIBS} {OBJECTS}
+	{LINK}	{LOptions}					âˆ‚
+			-o {Application}				âˆ‚
+			"{3DOLibs}cstartup.o"		âˆ‚
+			{OBJECTS}					âˆ‚
+			{LIBS}
+	SetFile {Application} -c 'EaDJ' -t 'PROJ'
+	modbin {Application} -stack 0x2000 -debug
+	stripaif {Application} -o {Application}
+	if not `exists "{AppsDir}"`
+		newFolder "{AppsDir}"
+	end
+	move -y {Targ} "{AppsDir}"
+	move -y {Targ}.sym "{AppsDir}"
+
+#####################################
+#	Include file dependencies
+#####################################
+#{Application}.c		Æ’	{Application}.h
+
+
+symanim.c	Æ’ Sprite.h
+sprite.c Æ’ Sprite.h

--- a/release/examples/Jumpstart/Jumpstart2/Jumpstart_Animation/jsanimation.make
+++ b/release/examples/Jumpstart/Jumpstart2/Jumpstart_Animation/jsanimation.make
@@ -1,1 +1,93 @@
-######################################### Copyright (C) 1995, an unpublished work by The 3DO Company. All rights reserved.## This material contains confidential information that is the property of The 3DO Company.## Any unauthorized duplication, disclosure or use is prohibited.## $Id: jsanimation.make,v 1.8 1995/01/20 04:56:02 ceckhaus Exp $########################################   File:       jsanimation.make#   Target:     jsanimation#   Sources:    jsanimation.c#######################################		Symbol definitions#####################################App				=	jsanimationDebugFlag		= 	1ObjectDir		=	:Objects:SourceDir		=	:AppsDir			=	:Apps_Data:ExamplesLibDir	=	{3DOFolder}Examples:ExamplesLib:CC				=	armccLINK			=	armlinkWorkingDisk		= ######################################	Default compiler options#####################################COptions			= -fa -zps0 -za1 -i "{ExamplesLibDir}"CDebugOptions		= -g -d DEBUG={DebugFlag}LOptions			= -aif -r -b 0x00LStackSize			= 4096LDebugOptions		= -dModbinDebugOptions	= -debug######################################		Object files#####################################OBJECTS			=	{ObjectDir}{App}.c.o ¶					"{3DOLibs}"cstartup.oLIBS			=	¶					"{ExamplesLibDir}ExamplesLib.lib"  ¶					"{3DOLibs}Lib3DO.lib" ¶					"{3DOLibs}audio.lib" ¶					"{3DOLibs}music.lib" ¶					"{3DOLibs}operamath.lib" ¶					"{3DOLibs}filesystem.lib" ¶					"{3DOLibs}graphics.lib" ¶					"{3DOLibs}input.lib" ¶					"{3DOLibs}clib.lib"					######################################	Default build rules#####################################All				Ä	{App}{ObjectDir}		Ä	:.c.o	Ä	.c	{CC} -i "{3DOIncludes}" {COptions} {CDebugOptions} -o {TargDir}{Default}.c.o {DepDir}{Default}.c######################################	Target build rules#####################################{App} Ä {App}.make {OBJECTS}	{LINK} {LOptions} {LDebugOptions} ¶		{OBJECTS} ¶		{LIBS} ¶		-o "{WorkingDisk}"{Targ}	SetFile "{WorkingDisk}"{Targ} -c 'EaDJ' -t 'PROJ'	modbin "{WorkingDisk}"{Targ} -stack {LStackSize} {ModbinDebugOptions}	stripaif "{WorkingDisk}"{Targ} -o {Targ} -s {Targ}.sym	if not `exists "{AppsDir}"`		newFolder "{AppsDir}"	end	move -y {Targ} "{AppsDir}"	move -y {Targ}.sym "{AppsDir}"######################################	Additional Target Dependencies#####################################{ObjectDir}{App}.c.o			Ä	{App}.make
+
+#####################################
+##
+## Copyright (C) 1995, an unpublished work by The 3DO Company. All rights reserved.
+## This material contains confidential information that is the property of The 3DO Company.
+## Any unauthorized duplication, disclosure or use is prohibited.
+## $Id: jsanimation.make,v 1.8 1995/01/20 04:56:02 ceckhaus Exp $
+##
+#####################################
+
+#   File:       jsanimation.make
+#   Target:     jsanimation
+#   Sources:    jsanimation.c
+#
+
+#####################################
+#		Symbol definitions
+#####################################
+App				=	jsanimation
+DebugFlag		= 	1
+ObjectDir		=	:Objects:
+SourceDir		=	:
+AppsDir			=	:Apps_Data:
+ExamplesLibDir	=	{3DOFolder}Examples:ExamplesLib:
+CC				=	armcc
+LINK			=	armlink
+WorkingDisk		= 
+
+#####################################
+#	Default compiler options
+#####################################
+
+COptions			= -fa -zps0 -za1 -i "{ExamplesLibDir}"
+CDebugOptions		= -g -d DEBUG={DebugFlag}
+LOptions			= -aif -r -b 0x00
+LStackSize			= 4096
+LDebugOptions		= -d
+ModbinDebugOptions	= -debug
+
+#####################################
+#		Object files
+#####################################
+
+OBJECTS			=	{ObjectDir}{App}.c.o âˆ‚
+					"{3DOLibs}"cstartup.o
+
+LIBS			=	âˆ‚
+					"{ExamplesLibDir}ExamplesLib.lib"  âˆ‚
+					"{3DOLibs}Lib3DO.lib" âˆ‚
+					"{3DOLibs}audio.lib" âˆ‚
+					"{3DOLibs}music.lib" âˆ‚
+					"{3DOLibs}operamath.lib" âˆ‚
+					"{3DOLibs}filesystem.lib" âˆ‚
+					"{3DOLibs}graphics.lib" âˆ‚
+					"{3DOLibs}input.lib" âˆ‚
+					"{3DOLibs}clib.lib"
+					
+#####################################
+#	Default build rules
+#####################################
+
+All				Æ’	{App}
+
+{ObjectDir}		Æ’	:
+
+.c.o	Æ’	.c
+	{CC} -i "{3DOIncludes}" {COptions} {CDebugOptions} -o {TargDir}{Default}.c.o {DepDir}{Default}.c
+
+#####################################
+#	Target build rules
+#####################################
+
+{App} Æ’ {App}.make {OBJECTS}
+	{LINK} {LOptions} {LDebugOptions} âˆ‚
+		{OBJECTS} âˆ‚
+		{LIBS} âˆ‚
+		-o "{WorkingDisk}"{Targ}
+	SetFile "{WorkingDisk}"{Targ} -c 'EaDJ' -t 'PROJ'
+	modbin "{WorkingDisk}"{Targ} -stack {LStackSize} {ModbinDebugOptions}
+	stripaif "{WorkingDisk}"{Targ} -o {Targ} -s {Targ}.sym
+	if not `exists "{AppsDir}"`
+		newFolder "{AppsDir}"
+	end
+	move -y {Targ} "{AppsDir}"
+	move -y {Targ}.sym "{AppsDir}"
+
+#####################################
+#	Additional Target Dependencies
+#####################################
+
+{ObjectDir}{App}.c.o			Æ’	{App}.make
+
+

--- a/release/examples/Jumpstart/Jumpstart2/Jumpstart_Interactive_Music/jsinteractivemusic.make
+++ b/release/examples/Jumpstart/Jumpstart2/Jumpstart_Interactive_Music/jsinteractivemusic.make
@@ -1,1 +1,92 @@
-######################################### Copyright (C) 1995, an unpublished work by The 3DO Company. All rights reserved.## This material contains confidential information that is the property of The 3DO Company.## Any unauthorized duplication, disclosure or use is prohibited.## $Id: jsinteractivemusic.make,v 1.7 1995/01/20 04:56:10 ceckhaus Exp $#########################################   File:       jsinteractivemusic.make#   Target:     jsinteractivemusic#   Sources:    jsinteractivemusic.c#######################################	Symbol definitions#####################################App				=	jsinteractivemusicDebugFlag		=	1ObjectDir		=	:Objects:SourceDir		=	:AppsDir			=	:Apps_Data:ExamplesLibDir	=	{3DOFolder}Examples:ExamplesLib:CC				=	armccLINK			=	armlinkWorkingDisk		= ######################################	Default compiler options#####################################COptions			= -fa -zps0 -za1 -i "{ExamplesLibDir}"CDebugOptions		= -g -d DEBUG={DebugFlag}LOptions			= -aif -r -b 0x00LStackSize			= 4096LDebugOptions		= -dModbinDebugOptions	= -debug######################################	Object files#####################################OBJECTS			=	{ObjectDir}{App}.c.o ¶					"{3DOLibs}"cstartup.oLIBS			=	¶					"{ExamplesLibDir}ExamplesLib.lib"  ¶					"{3DOLibs}Lib3DO.lib" ¶					"{3DOLibs}audio.lib" ¶					"{3DOLibs}music.lib" ¶					"{3DOLibs}operamath.lib" ¶					"{3DOLibs}filesystem.lib" ¶					"{3DOLibs}graphics.lib" ¶					"{3DOLibs}input.lib" ¶					"{3DOLibs}clib.lib"					######################################	Default build rules#####################################All				Ä	{App}{ObjectDir}		Ä	:.c.o	Ä	.c	{CC} -i "{3DOIncludes}" {COptions} {CDebugOptions} -o {TargDir}{Default}.c.o {DepDir}{Default}.c######################################	Target build rules#####################################{App} Ä {App}.make {OBJECTS}	{LINK} {LOptions} {LDebugOptions} ¶		{OBJECTS} ¶		{LIBS} ¶		-o "{WorkingDisk}"{Targ}	SetFile "{WorkingDisk}"{Targ} -c 'EaDJ' -t 'PROJ'	modbin "{WorkingDisk}"{Targ} -stack {LStackSize} {ModbinDebugOptions}	stripaif "{WorkingDisk}"{Targ} -o {Targ} -s {Targ}.sym	if not `exists "{AppsDir}"`		newFolder "{AppsDir}"	end	move -y {Targ} "{AppsDir}"	move -y {Targ}.sym "{AppsDir}"######################################	Additional Target Dependencies#####################################{ObjectDir}{App}.c.o			Ä	{App}.make
+
+#####################################
+##
+## Copyright (C) 1995, an unpublished work by The 3DO Company. All rights reserved.
+## This material contains confidential information that is the property of The 3DO Company.
+## Any unauthorized duplication, disclosure or use is prohibited.
+## $Id: jsinteractivemusic.make,v 1.7 1995/01/20 04:56:10 ceckhaus Exp $
+##
+#####################################
+
+#
+#   File:       jsinteractivemusic.make
+#   Target:     jsinteractivemusic
+#   Sources:    jsinteractivemusic.c
+#
+
+#####################################
+#	Symbol definitions
+#####################################
+
+App				=	jsinteractivemusic
+DebugFlag		=	1
+ObjectDir		=	:Objects:
+SourceDir		=	:
+AppsDir			=	:Apps_Data:
+ExamplesLibDir	=	{3DOFolder}Examples:ExamplesLib:
+CC				=	armcc
+LINK			=	armlink
+WorkingDisk		= 
+
+#####################################
+#	Default compiler options
+#####################################
+
+COptions			= -fa -zps0 -za1 -i "{ExamplesLibDir}"
+CDebugOptions		= -g -d DEBUG={DebugFlag}
+LOptions			= -aif -r -b 0x00
+LStackSize			= 4096
+LDebugOptions		= -d
+ModbinDebugOptions	= -debug
+
+#####################################
+#	Object files
+#####################################
+
+OBJECTS			=	{ObjectDir}{App}.c.o âˆ‚
+					"{3DOLibs}"cstartup.o
+
+LIBS			=	âˆ‚
+					"{ExamplesLibDir}ExamplesLib.lib"  âˆ‚
+					"{3DOLibs}Lib3DO.lib" âˆ‚
+					"{3DOLibs}audio.lib" âˆ‚
+					"{3DOLibs}music.lib" âˆ‚
+					"{3DOLibs}operamath.lib" âˆ‚
+					"{3DOLibs}filesystem.lib" âˆ‚
+					"{3DOLibs}graphics.lib" âˆ‚
+					"{3DOLibs}input.lib" âˆ‚
+					"{3DOLibs}clib.lib"
+					
+#####################################
+#	Default build rules
+#####################################
+All				Æ’	{App}
+
+{ObjectDir}		Æ’	:
+
+.c.o	Æ’	.c
+	{CC} -i "{3DOIncludes}" {COptions} {CDebugOptions} -o {TargDir}{Default}.c.o {DepDir}{Default}.c
+
+#####################################
+#	Target build rules
+#####################################
+
+{App} Æ’ {App}.make {OBJECTS}
+	{LINK} {LOptions} {LDebugOptions} âˆ‚
+		{OBJECTS} âˆ‚
+		{LIBS} âˆ‚
+		-o "{WorkingDisk}"{Targ}
+	SetFile "{WorkingDisk}"{Targ} -c 'EaDJ' -t 'PROJ'
+	modbin "{WorkingDisk}"{Targ} -stack {LStackSize} {ModbinDebugOptions}
+	stripaif "{WorkingDisk}"{Targ} -o {Targ} -s {Targ}.sym
+	if not `exists "{AppsDir}"`
+		newFolder "{AppsDir}"
+	end
+	move -y {Targ} "{AppsDir}"
+	move -y {Targ}.sym "{AppsDir}"
+
+#####################################
+#	Additional Target Dependencies
+#####################################
+
+{ObjectDir}{App}.c.o			Æ’	{App}.make

--- a/release/examples/Jumpstart/Jumpstart2/Jumpstart_Interactive_Music/jsintmusicthread.make
+++ b/release/examples/Jumpstart/Jumpstart2/Jumpstart_Interactive_Music/jsintmusicthread.make
@@ -1,1 +1,93 @@
-######################################### Copyright (C) 1995, an unpublished work by The 3DO Company. All rights reserved.## This material contains confidential information that is the property of The 3DO Company.## Any unauthorized duplication, disclosure or use is prohibited.## $Id: jsintmusicthread.make,v 1.7 1995/01/20 04:56:10 ceckhaus Exp $#########################################   File:       jsintmusicthread.make#   Target:     jsintmusicthread#   Sources:    jsintmusicthread.c#######################################	Symbol definitions#####################################App				=	jsintmusicthreadDebugFlag		=	1ObjectDir		=	:Objects:SourceDir		=	:AppsDir			=	:Apps_Data:ExamplesLibDir	=	{3DOFolder}Examples:ExamplesLib:CC				=	armccLINK			=	armlinkWorkingDisk		= ######################################	Default compiler options#####################################COptions			= -fa -zps0 -za1 -i "{ExamplesLibDir}"CDebugOptions		= -g -d DEBUG={DebugFlag}LOptions			= -aif -r -b 0x00LStackSize			= 4096LDebugOptions		= -dModbinDebugOptions	= -debug######################################	Object files#####################################OBJECTS			=	{ObjectDir}{App}.c.o ¶					"{3DOLibs}"cstartup.oLIBS			=	¶					"{ExamplesLibDir}ExamplesLib.lib"  ¶					"{3DOLibs}Lib3DO.lib" ¶					"{3DOLibs}audio.lib" ¶					"{3DOLibs}music.lib" ¶					"{3DOLibs}operamath.lib" ¶					"{3DOLibs}filesystem.lib" ¶					"{3DOLibs}graphics.lib" ¶					"{3DOLibs}input.lib" ¶					"{3DOLibs}clib.lib"					######################################	Default build rules#####################################All				Ä	{App}{ObjectDir}		Ä	:.c.o	Ä	.c	{CC} -i "{3DOIncludes}" {COptions} {CDebugOptions} -o {TargDir}{Default}.c.o {DepDir}{Default}.c######################################	Target build rules#####################################{App} Ä {App}.make {OBJECTS}	{LINK} {LOptions} {LDebugOptions} ¶		{OBJECTS} ¶		{LIBS} ¶		-o "{WorkingDisk}"{Targ}	SetFile "{WorkingDisk}"{Targ} -c 'EaDJ' -t 'PROJ'	modbin "{WorkingDisk}"{Targ} -stack {LStackSize} {ModbinDebugOptions}	stripaif "{WorkingDisk}"{Targ} -o {Targ} -s {Targ}.sym	if not `exists "{AppsDir}"`		newFolder "{AppsDir}"	end	move -y {Targ} "{AppsDir}"	move -y {Targ}.sym "{AppsDir}"######################################	Additional Target Dependencies#####################################{ObjectDir}{App}.c.o			Ä	{App}.make
+
+#####################################
+##
+## Copyright (C) 1995, an unpublished work by The 3DO Company. All rights reserved.
+## This material contains confidential information that is the property of The 3DO Company.
+## Any unauthorized duplication, disclosure or use is prohibited.
+## $Id: jsintmusicthread.make,v 1.7 1995/01/20 04:56:10 ceckhaus Exp $
+##
+#####################################
+
+#
+#   File:       jsintmusicthread.make
+#   Target:     jsintmusicthread
+#   Sources:    jsintmusicthread.c
+#
+
+#####################################
+#	Symbol definitions
+#####################################
+
+App				=	jsintmusicthread
+DebugFlag		=	1
+ObjectDir		=	:Objects:
+SourceDir		=	:
+AppsDir			=	:Apps_Data:
+ExamplesLibDir	=	{3DOFolder}Examples:ExamplesLib:
+CC				=	armcc
+LINK			=	armlink
+WorkingDisk		= 
+
+#####################################
+#	Default compiler options
+#####################################
+
+COptions			= -fa -zps0 -za1 -i "{ExamplesLibDir}"
+CDebugOptions		= -g -d DEBUG={DebugFlag}
+LOptions			= -aif -r -b 0x00
+LStackSize			= 4096
+LDebugOptions		= -d
+ModbinDebugOptions	= -debug
+
+#####################################
+#	Object files
+#####################################
+
+OBJECTS			=	{ObjectDir}{App}.c.o âˆ‚
+					"{3DOLibs}"cstartup.o
+
+LIBS			=	âˆ‚
+					"{ExamplesLibDir}ExamplesLib.lib"  âˆ‚
+					"{3DOLibs}Lib3DO.lib" âˆ‚
+					"{3DOLibs}audio.lib" âˆ‚
+					"{3DOLibs}music.lib" âˆ‚
+					"{3DOLibs}operamath.lib" âˆ‚
+					"{3DOLibs}filesystem.lib" âˆ‚
+					"{3DOLibs}graphics.lib" âˆ‚
+					"{3DOLibs}input.lib" âˆ‚
+					"{3DOLibs}clib.lib"
+					
+#####################################
+#	Default build rules
+#####################################
+
+All				Æ’	{App}
+
+{ObjectDir}		Æ’	:
+
+.c.o	Æ’	.c
+	{CC} -i "{3DOIncludes}" {COptions} {CDebugOptions} -o {TargDir}{Default}.c.o {DepDir}{Default}.c
+
+#####################################
+#	Target build rules
+#####################################
+
+{App} Æ’ {App}.make {OBJECTS}
+	{LINK} {LOptions} {LDebugOptions} âˆ‚
+		{OBJECTS} âˆ‚
+		{LIBS} âˆ‚
+		-o "{WorkingDisk}"{Targ}
+	SetFile "{WorkingDisk}"{Targ} -c 'EaDJ' -t 'PROJ'
+	modbin "{WorkingDisk}"{Targ} -stack {LStackSize} {ModbinDebugOptions}
+	stripaif "{WorkingDisk}"{Targ} -o {Targ} -s {Targ}.sym
+	if not `exists "{AppsDir}"`
+		newFolder "{AppsDir}"
+	end
+	move -y {Targ} "{AppsDir}"
+	move -y {Targ}.sym "{AppsDir}"
+
+#####################################
+#	Additional Target Dependencies
+#####################################
+
+{ObjectDir}{App}.c.o			Æ’	{App}.make

--- a/release/examples/Jumpstart/Jumpstart2/Jumpstart_Interactive_Music/jsplaybgndmusic.make
+++ b/release/examples/Jumpstart/Jumpstart2/Jumpstart_Interactive_Music/jsplaybgndmusic.make
@@ -1,1 +1,93 @@
-######################################### Copyright (C) 1995, an unpublished work by The 3DO Company. All rights reserved.## This material contains confidential information that is the property of The 3DO Company.## Any unauthorized duplication, disclosure or use is prohibited.## $Id: jsplaybgndmusic.make,v 1.6 1995/01/20 04:56:10 ceckhaus Exp $########################################   File:       jsplaybgndmusic.make#   Target:     jsplaybgndmusic#   Sources:    jsplaybgndmusic.c#######################################	Symbol definitions#####################################App				= 	jsplaybgndmusicDebugFlag		=	1ObjectDir		=	:Objects:SourceDir		=	:AppsDir			=	:Apps_Data:ExamplesLibDir	=	{3DOFolder}Examples:ExamplesLib:CC				=	armccLINK			=	armlinkWorkingDisk		= ######################################	Default compiler options#####################################COptions			= -fa -zps0 -za1 -i "{ExamplesLibDir}"CDebugOptions		= -g -d DEBUG={DebugFlag}LOptions			= -aif -r -b 0x00LStackSize			= 4096LDebugOptions		= -dModbinDebugOptions	= -debug######################################	Object files#####################################OBJECTS			=	{ObjectDir}{App}.c.o ¶					"{3DOLibs}"cstartup.oLIBS			=	 ¶					"{ExamplesLibDir}ExamplesLib.lib"  ¶					"{3DOLibs}Lib3DO.lib" ¶					"{3DOLibs}audio.lib" ¶					"{3DOLibs}music.lib" ¶					"{3DOLibs}operamath.lib" ¶					"{3DOLibs}filesystem.lib" ¶					"{3DOLibs}graphics.lib" ¶					"{3DOLibs}input.lib" ¶					"{3DOLibs}clib.lib"######################################	Default build rules#####################################All				Ä	{App}{ObjectDir}		Ä	:.c.o	Ä	.c	{CC} -i "{3DOIncludes}" {COptions} {CDebugOptions} -o {TargDir}{Default}.c.o {DepDir}{Default}.c######################################	Target build rules#####################################{App} Ä {App}.make {OBJECTS}	{LINK} {LOptions} {LDebugOptions} ¶		{OBJECTS} ¶		{LIBS} ¶		-o "{WorkingDisk}"{Targ}	SetFile "{WorkingDisk}"{Targ} -c 'EaDJ' -t 'PROJ'	modbin "{WorkingDisk}"{Targ} -stack {LStackSize} {ModbinDebugOptions}	stripaif "{WorkingDisk}"{Targ} -o {Targ} -s {Targ}.sym	if not `exists "{AppsDir}"`		newFolder "{AppsDir}"	end	move -y {Targ} "{AppsDir}"	move -y {Targ}.sym "{AppsDir}"######################################	Additional Target Dependencies#####################################{ObjectDir}{App}.c.o			Ä	{App}.make
+
+#####################################
+##
+## Copyright (C) 1995, an unpublished work by The 3DO Company. All rights reserved.
+## This material contains confidential information that is the property of The 3DO Company.
+## Any unauthorized duplication, disclosure or use is prohibited.
+## $Id: jsplaybgndmusic.make,v 1.6 1995/01/20 04:56:10 ceckhaus Exp $
+##
+#####################################
+
+#   File:       jsplaybgndmusic.make
+#   Target:     jsplaybgndmusic
+#   Sources:    jsplaybgndmusic.c
+#
+
+#####################################
+#	Symbol definitions
+#####################################
+
+App				= 	jsplaybgndmusic
+DebugFlag		=	1
+ObjectDir		=	:Objects:
+SourceDir		=	:
+AppsDir			=	:Apps_Data:
+ExamplesLibDir	=	{3DOFolder}Examples:ExamplesLib:
+CC				=	armcc
+LINK			=	armlink
+WorkingDisk		= 
+
+#####################################
+#	Default compiler options
+#####################################
+
+COptions			= -fa -zps0 -za1 -i "{ExamplesLibDir}"
+CDebugOptions		= -g -d DEBUG={DebugFlag}
+LOptions			= -aif -r -b 0x00
+LStackSize			= 4096
+LDebugOptions		= -d
+ModbinDebugOptions	= -debug
+
+#####################################
+#	Object files
+#####################################
+
+OBJECTS			=	{ObjectDir}{App}.c.o âˆ‚
+					"{3DOLibs}"cstartup.o
+
+LIBS			=	 âˆ‚
+					"{ExamplesLibDir}ExamplesLib.lib"  âˆ‚
+					"{3DOLibs}Lib3DO.lib" âˆ‚
+					"{3DOLibs}audio.lib" âˆ‚
+					"{3DOLibs}music.lib" âˆ‚
+					"{3DOLibs}operamath.lib" âˆ‚
+					"{3DOLibs}filesystem.lib" âˆ‚
+					"{3DOLibs}graphics.lib" âˆ‚
+					"{3DOLibs}input.lib" âˆ‚
+					"{3DOLibs}clib.lib"
+
+#####################################
+#	Default build rules
+#####################################
+
+All				Æ’	{App}
+
+{ObjectDir}		Æ’	:
+
+.c.o	Æ’	.c
+	{CC} -i "{3DOIncludes}" {COptions} {CDebugOptions} -o {TargDir}{Default}.c.o {DepDir}{Default}.c
+
+#####################################
+#	Target build rules
+#####################################
+
+{App} Æ’ {App}.make {OBJECTS}
+	{LINK} {LOptions} {LDebugOptions} âˆ‚
+		{OBJECTS} âˆ‚
+		{LIBS} âˆ‚
+		-o "{WorkingDisk}"{Targ}
+	SetFile "{WorkingDisk}"{Targ} -c 'EaDJ' -t 'PROJ'
+	modbin "{WorkingDisk}"{Targ} -stack {LStackSize} {ModbinDebugOptions}
+	stripaif "{WorkingDisk}"{Targ} -o {Targ} -s {Targ}.sym
+	if not `exists "{AppsDir}"`
+		newFolder "{AppsDir}"
+	end
+	move -y {Targ} "{AppsDir}"
+	move -y {Targ}.sym "{AppsDir}"
+
+#####################################
+#	Additional Target Dependencies
+#####################################
+
+{ObjectDir}{App}.c.o			Æ’	{App}.make
+

--- a/release/examples/Jumpstart/Jumpstart2/Jumpstart_Interactive_Sound/jsinteractivesound.make
+++ b/release/examples/Jumpstart/Jumpstart2/Jumpstart_Interactive_Sound/jsinteractivesound.make
@@ -1,1 +1,93 @@
-######################################### Copyright (C) 1995, an unpublished work by The 3DO Company. All rights reserved.## This material contains confidential information that is the property of The 3DO Company.## Any unauthorized duplication, disclosure or use is prohibited.## $Id: jsinteractivesound.make,v 1.7 1995/01/20 04:56:46 ceckhaus Exp $#########################################   File:       jsinteractivesound.make#   Target:     jsinteractivesound#   Sources:    jsinteractivesound.c#######################################		Symbol definitions#####################################App				=	jsinteractivesoundDebugFlag		=	1ObjectDir		=	:Objects:SourceDir		=	:AppsDir			=	:Apps_Data:ExamplesLibDir	=	{3DOFolder}Examples:ExamplesLib:CC				=	armccLINK			=	armlinkWorkingDisk		= ######################################	Default compiler options#####################################COptions			= -fa -zps0 -za1 -i "{ExamplesLibDir}"CDebugOptions		= -g -d DEBUG={DebugFlag}LOptions			= -aif -r -b 0x00LStackSize			= 4096LDebugOptions		= -dModbinDebugOptions	= -debug######################################		Object files#####################################OBJECTS			=	{ObjectDir}{App}.c.o ¶					"{3DOLibs}"cstartup.oLIBS			=	¶					"{ExamplesLibDir}ExamplesLib.lib"  ¶					"{3DOLibs}Lib3DO.lib" ¶					"{3DOLibs}audio.lib" ¶					"{3DOLibs}music.lib" ¶					"{3DOLibs}operamath.lib" ¶					"{3DOLibs}filesystem.lib" ¶					"{3DOLibs}graphics.lib" ¶					"{3DOLibs}input.lib" ¶					"{3DOLibs}clib.lib"######################################	Default build rules#####################################All				Ä	{App}{ObjectDir}		Ä	:.c.o	Ä	.c	{CC} -i "{3DOIncludes}" {COptions} {CDebugOptions} -o {TargDir}{Default}.c.o {DepDir}{Default}.c######################################	Target build rules#####################################{App} Ä {App}.make {OBJECTS}	{LINK} {LOptions} {LDebugOptions} ¶		{OBJECTS} ¶		{LIBS} ¶		-o "{WorkingDisk}"{Targ}	SetFile "{WorkingDisk}"{Targ} -c 'EaDJ' -t 'PROJ'	modbin "{WorkingDisk}"{Targ} -stack {LStackSize} {ModbinDebugOptions}	stripaif "{WorkingDisk}"{Targ} -o {Targ} -s {Targ}.sym	if not `exists "{AppsDir}"`		newFolder "{AppsDir}"	end	move -y {Targ} "{AppsDir}"	move -y {Targ}.sym "{AppsDir}"######################################	Include file dependencies#####################################{ObjectDir}{App}.c.o			Ä	{App}.make
+
+#####################################
+##
+## Copyright (C) 1995, an unpublished work by The 3DO Company. All rights reserved.
+## This material contains confidential information that is the property of The 3DO Company.
+## Any unauthorized duplication, disclosure or use is prohibited.
+## $Id: jsinteractivesound.make,v 1.7 1995/01/20 04:56:46 ceckhaus Exp $
+##
+#####################################
+
+#
+#   File:       jsinteractivesound.make
+#   Target:     jsinteractivesound
+#   Sources:    jsinteractivesound.c
+#
+
+#####################################
+#		Symbol definitions
+#####################################
+
+App				=	jsinteractivesound
+DebugFlag		=	1
+ObjectDir		=	:Objects:
+SourceDir		=	:
+AppsDir			=	:Apps_Data:
+ExamplesLibDir	=	{3DOFolder}Examples:ExamplesLib:
+CC				=	armcc
+LINK			=	armlink
+WorkingDisk		= 
+
+#####################################
+#	Default compiler options
+#####################################
+
+COptions			= -fa -zps0 -za1 -i "{ExamplesLibDir}"
+CDebugOptions		= -g -d DEBUG={DebugFlag}
+LOptions			= -aif -r -b 0x00
+LStackSize			= 4096
+LDebugOptions		= -d
+ModbinDebugOptions	= -debug
+
+#####################################
+#		Object files
+#####################################
+
+OBJECTS			=	{ObjectDir}{App}.c.o âˆ‚
+					"{3DOLibs}"cstartup.o
+
+LIBS			=	âˆ‚
+					"{ExamplesLibDir}ExamplesLib.lib"  âˆ‚
+					"{3DOLibs}Lib3DO.lib" âˆ‚
+					"{3DOLibs}audio.lib" âˆ‚
+					"{3DOLibs}music.lib" âˆ‚
+					"{3DOLibs}operamath.lib" âˆ‚
+					"{3DOLibs}filesystem.lib" âˆ‚
+					"{3DOLibs}graphics.lib" âˆ‚
+					"{3DOLibs}input.lib" âˆ‚
+					"{3DOLibs}clib.lib"
+
+#####################################
+#	Default build rules
+#####################################
+
+All				Æ’	{App}
+
+{ObjectDir}		Æ’	:
+
+.c.o	Æ’	.c
+	{CC} -i "{3DOIncludes}" {COptions} {CDebugOptions} -o {TargDir}{Default}.c.o {DepDir}{Default}.c
+
+#####################################
+#	Target build rules
+#####################################
+
+{App} Æ’ {App}.make {OBJECTS}
+	{LINK} {LOptions} {LDebugOptions} âˆ‚
+		{OBJECTS} âˆ‚
+		{LIBS} âˆ‚
+		-o "{WorkingDisk}"{Targ}
+	SetFile "{WorkingDisk}"{Targ} -c 'EaDJ' -t 'PROJ'
+	modbin "{WorkingDisk}"{Targ} -stack {LStackSize} {ModbinDebugOptions}
+	stripaif "{WorkingDisk}"{Targ} -o {Targ} -s {Targ}.sym
+	if not `exists "{AppsDir}"`
+		newFolder "{AppsDir}"
+	end
+	move -y {Targ} "{AppsDir}"
+	move -y {Targ}.sym "{AppsDir}"
+
+#####################################
+#	Include file dependencies
+#####################################
+
+{ObjectDir}{App}.c.o			Æ’	{App}.make

--- a/release/examples/Jumpstart/Jumpstart2/Jumpstart_Move_Cel/jsmovecel.make
+++ b/release/examples/Jumpstart/Jumpstart2/Jumpstart_Move_Cel/jsmovecel.make
@@ -1,1 +1,93 @@
-######################################### Copyright (C) 1995, an unpublished work by The 3DO Company. All rights reserved.## This material contains confidential information that is the property of The 3DO Company.## Any unauthorized duplication, disclosure or use is prohibited.## $Id: jsmovecel.make,v 1.6 1995/01/20 04:56:56 ceckhaus Exp $########################################   File:       jsmovecel.make#   Target:     jsmovecel#   Sources:    jsmovecel.c#######################################		Symbol definitions#####################################App				=	jsmovecelDebugFlag		=	1ObjectDir		=	:Objects:SourceDir		=	:AppsDir			=	:Apps_Data:ExamplesLibDir	=	{3DOFolder}Examples:ExamplesLib:CC				=	armccLINK			=	armlinkWorkingDisk		= ######################################	Default compiler options#####################################COptions			= -fa -zps0 -za1 -i "{ExamplesLibDir}"CDebugOptions		= -g -d DEBUG={DebugFlag}LOptions			= -aif -r -b 0x00LStackSize			= 4096LDebugOptions		= -dModbinDebugOptions	= -debug######################################		Object files#####################################OBJECTS			=	{ObjectDir}{App}.c.o ¶					"{3DOLibs}"cstartup.oLIBS			=	¶					"{ExamplesLibDir}ExamplesLib.lib"  ¶					"{3DOLibs}Lib3DO.lib" ¶					"{3DOLibs}audio.lib" ¶					"{3DOLibs}music.lib" ¶					"{3DOLibs}operamath.lib" ¶					"{3DOLibs}filesystem.lib" ¶					"{3DOLibs}graphics.lib" ¶					"{3DOLibs}input.lib" ¶					"{3DOLibs}clib.lib"					######################################	Default build rules#####################################All				Ä	{App}{ObjectDir}		Ä	:.c.o	Ä	.c	{CC} -i "{3DOIncludes}" {COptions} {CDebugOptions} -o {TargDir}{Default}.c.o {DepDir}{Default}.c######################################	Target build rules#####################################{App} Ä {App}.make {OBJECTS}	{LINK} {LOptions} {LDebugOptions} ¶		{OBJECTS} ¶		{LIBS} ¶		-o "{WorkingDisk}"{Targ}	SetFile "{WorkingDisk}"{Targ} -c 'EaDJ' -t 'PROJ'	modbin "{WorkingDisk}"{Targ} -stack {LStackSize} {ModbinDebugOptions}	stripaif "{WorkingDisk}"{Targ} -o {Targ} -s {Targ}.sym	if not `exists "{AppsDir}"`		newFolder "{AppsDir}"	end	move -y {Targ} "{AppsDir}"	move -y {Targ}.sym "{AppsDir}"######################################	Include file dependencies#####################################{ObjectDir}{App}.c.o			Ä	{App}.make
+
+#####################################
+##
+## Copyright (C) 1995, an unpublished work by The 3DO Company. All rights reserved.
+## This material contains confidential information that is the property of The 3DO Company.
+## Any unauthorized duplication, disclosure or use is prohibited.
+## $Id: jsmovecel.make,v 1.6 1995/01/20 04:56:56 ceckhaus Exp $
+##
+#####################################
+
+#   File:       jsmovecel.make
+#   Target:     jsmovecel
+#   Sources:    jsmovecel.c
+#
+
+#####################################
+#		Symbol definitions
+#####################################
+App				=	jsmovecel
+DebugFlag		=	1
+ObjectDir		=	:Objects:
+SourceDir		=	:
+AppsDir			=	:Apps_Data:
+ExamplesLibDir	=	{3DOFolder}Examples:ExamplesLib:
+CC				=	armcc
+LINK			=	armlink
+WorkingDisk		= 
+
+#####################################
+#	Default compiler options
+#####################################
+
+COptions			= -fa -zps0 -za1 -i "{ExamplesLibDir}"
+CDebugOptions		= -g -d DEBUG={DebugFlag}
+LOptions			= -aif -r -b 0x00
+LStackSize			= 4096
+LDebugOptions		= -d
+ModbinDebugOptions	= -debug
+
+#####################################
+#		Object files
+#####################################
+
+OBJECTS			=	{ObjectDir}{App}.c.o âˆ‚
+					"{3DOLibs}"cstartup.o
+
+LIBS			=	âˆ‚
+					"{ExamplesLibDir}ExamplesLib.lib"  âˆ‚
+					"{3DOLibs}Lib3DO.lib" âˆ‚
+					"{3DOLibs}audio.lib" âˆ‚
+					"{3DOLibs}music.lib" âˆ‚
+					"{3DOLibs}operamath.lib" âˆ‚
+					"{3DOLibs}filesystem.lib" âˆ‚
+					"{3DOLibs}graphics.lib" âˆ‚
+					"{3DOLibs}input.lib" âˆ‚
+					"{3DOLibs}clib.lib"
+					
+#####################################
+#	Default build rules
+#####################################
+
+All				Æ’	{App}
+
+{ObjectDir}		Æ’	:
+
+.c.o	Æ’	.c
+	{CC} -i "{3DOIncludes}" {COptions} {CDebugOptions} -o {TargDir}{Default}.c.o {DepDir}{Default}.c
+
+#####################################
+#	Target build rules
+#####################################
+
+{App} Æ’ {App}.make {OBJECTS}
+	{LINK} {LOptions} {LDebugOptions} âˆ‚
+		{OBJECTS} âˆ‚
+		{LIBS} âˆ‚
+		-o "{WorkingDisk}"{Targ}
+	SetFile "{WorkingDisk}"{Targ} -c 'EaDJ' -t 'PROJ'
+	modbin "{WorkingDisk}"{Targ} -stack {LStackSize} {ModbinDebugOptions}
+	stripaif "{WorkingDisk}"{Targ} -o {Targ} -s {Targ}.sym
+	if not `exists "{AppsDir}"`
+		newFolder "{AppsDir}"
+	end
+	move -y {Targ} "{AppsDir}"
+	move -y {Targ}.sym "{AppsDir}"
+
+#####################################
+#	Include file dependencies
+#####################################
+
+{ObjectDir}{App}.c.o			Æ’	{App}.make
+
+

--- a/release/examples/Jumpstart/Jumpstart2/Jumpstart_Show_Cel/jsshowcel.make
+++ b/release/examples/Jumpstart/Jumpstart2/Jumpstart_Show_Cel/jsshowcel.make
@@ -1,1 +1,93 @@
-######################################### Copyright (C) 1995, an unpublished work by The 3DO Company. All rights reserved.## This material contains confidential information that is the property of The 3DO Company.## Any unauthorized duplication, disclosure or use is prohibited.## $Id: jsshowcel.make,v 1.7 1995/01/20 04:57:02 ceckhaus Exp $########################################   File:       jsshowcel.make#   Target:     jsshowcel#   Sources:    jsshowcel.c#######################################	Symbol definitions#####################################App				= jsshowcelDebugFlag		= 1ObjectDir		= :Objects:SourceDir		= :AppsDir			= :Apps_Data:ExamplesLibDir	= {3DOFolder}Examples:ExamplesLib:CC				= armccLINK			= armlinkWorkingDisk		= ######################################	Default compiler options#####################################COptions			= -fa -zps0 -za1 -i "{ExamplesLibDir}"CDebugOptions		= -g -d DEBUG={DebugFlag}LOptions			= -aif -r -b 0x00LStackSize			= 4096LDebugOptions		= -dModbinDebugOptions	= -debug######################################	Object files#####################################OBJECTS			=	{ObjectDir}jsshowcel.c.o ¶					"{3DOLibs}"cstartup.oLIBS			=	 ¶					"{ExamplesLibDir}ExamplesLib.lib"  ¶					"{3DOLibs}Lib3DO.lib" ¶					"{3DOLibs}audio.lib" ¶					"{3DOLibs}music.lib" ¶					"{3DOLibs}operamath.lib" ¶					"{3DOLibs}filesystem.lib" ¶					"{3DOLibs}graphics.lib" ¶					"{3DOLibs}input.lib" ¶					"{3DOLibs}clib.lib"######################################	Default build rules#####################################All				Ä	{App}{ObjectDir}		Ä	:.c.o	Ä	.c	{CC} -i "{3DOIncludes}" {COptions} {CDebugOptions} -o {TargDir}{Default}.c.o {DepDir}{Default}.c######################################	Target build rules#####################################{App} Ä {App}.make {OBJECTS}	{LINK} {LOptions} {LDebugOptions} ¶		{OBJECTS} ¶		{LIBS} ¶		-o "{WorkingDisk}"{Targ}	SetFile "{WorkingDisk}"{Targ} -c 'EaDJ' -t 'PROJ'	modbin "{WorkingDisk}"{Targ} -stack {LStackSize} {ModbinDebugOptions}	stripaif "{WorkingDisk}"{Targ} -o {Targ} -s {Targ}.sym	if not `exists "{AppsDir}"`		newFolder "{AppsDir}"	end	move -y {Targ} "{AppsDir}"	move -y {Targ}.sym "{AppsDir}"######################################	Additional Target Dependencies#####################################{ObjectDir}{App}.c.o			Ä	{App}.make
+
+#####################################
+##
+## Copyright (C) 1995, an unpublished work by The 3DO Company. All rights reserved.
+## This material contains confidential information that is the property of The 3DO Company.
+## Any unauthorized duplication, disclosure or use is prohibited.
+## $Id: jsshowcel.make,v 1.7 1995/01/20 04:57:02 ceckhaus Exp $
+##
+#####################################
+
+#   File:       jsshowcel.make
+#   Target:     jsshowcel
+#   Sources:    jsshowcel.c
+#
+
+#####################################
+#	Symbol definitions
+#####################################
+
+App				= jsshowcel
+DebugFlag		= 1
+ObjectDir		= :Objects:
+SourceDir		= :
+AppsDir			= :Apps_Data:
+ExamplesLibDir	= {3DOFolder}Examples:ExamplesLib:
+CC				= armcc
+LINK			= armlink
+WorkingDisk		= 
+
+#####################################
+#	Default compiler options
+#####################################
+
+COptions			= -fa -zps0 -za1 -i "{ExamplesLibDir}"
+CDebugOptions		= -g -d DEBUG={DebugFlag}
+LOptions			= -aif -r -b 0x00
+LStackSize			= 4096
+LDebugOptions		= -d
+ModbinDebugOptions	= -debug
+
+#####################################
+#	Object files
+#####################################
+
+OBJECTS			=	{ObjectDir}jsshowcel.c.o âˆ‚
+					"{3DOLibs}"cstartup.o
+
+LIBS			=	 âˆ‚
+					"{ExamplesLibDir}ExamplesLib.lib"  âˆ‚
+					"{3DOLibs}Lib3DO.lib" âˆ‚
+					"{3DOLibs}audio.lib" âˆ‚
+					"{3DOLibs}music.lib" âˆ‚
+					"{3DOLibs}operamath.lib" âˆ‚
+					"{3DOLibs}filesystem.lib" âˆ‚
+					"{3DOLibs}graphics.lib" âˆ‚
+					"{3DOLibs}input.lib" âˆ‚
+					"{3DOLibs}clib.lib"
+
+#####################################
+#	Default build rules
+#####################################
+
+All				Æ’	{App}
+
+{ObjectDir}		Æ’	:
+
+.c.o	Æ’	.c
+	{CC} -i "{3DOIncludes}" {COptions} {CDebugOptions} -o {TargDir}{Default}.c.o {DepDir}{Default}.c
+
+#####################################
+#	Target build rules
+#####################################
+
+{App} Æ’ {App}.make {OBJECTS}
+	{LINK} {LOptions} {LDebugOptions} âˆ‚
+		{OBJECTS} âˆ‚
+		{LIBS} âˆ‚
+		-o "{WorkingDisk}"{Targ}
+	SetFile "{WorkingDisk}"{Targ} -c 'EaDJ' -t 'PROJ'
+	modbin "{WorkingDisk}"{Targ} -stack {LStackSize} {ModbinDebugOptions}
+	stripaif "{WorkingDisk}"{Targ} -o {Targ} -s {Targ}.sym
+	if not `exists "{AppsDir}"`
+		newFolder "{AppsDir}"
+	end
+	move -y {Targ} "{AppsDir}"
+	move -y {Targ}.sym "{AppsDir}"
+
+#####################################
+#	Additional Target Dependencies
+#####################################
+
+{ObjectDir}{App}.c.o			Æ’	{App}.make
+

--- a/release/examples/Jumpstart/Jumpstart2/Jumpstart_Slideshow/jsbasicslideshow.make
+++ b/release/examples/Jumpstart/Jumpstart2/Jumpstart_Slideshow/jsbasicslideshow.make
@@ -1,1 +1,93 @@
-######################################### Copyright (C) 1995, an unpublished work by The 3DO Company. All rights reserved.## This material contains confidential information that is the property of The 3DO Company.## Any unauthorized duplication, disclosure or use is prohibited.## $Id: jsbasicslideshow.make,v 1.7 1995/01/20 04:57:12 ceckhaus Exp $########################################   File:       jsbasicslideshow.make#   Target:     jsbasicslideshow#   Sources:    jsbasicslideshow.c#######################################		Symbol definitions#####################################App				=	jsbasicslideshowDebugFlag		=	1ObjectDir		=	:Objects:SourceDir		=	:AppsDir			=	:Apps_Data:ExamplesLibDir	=	{3DOFolder}Examples:ExamplesLib:CC				=	armccLINK			=	armlinkWorkingDisk		= ######################################	Default compiler options#####################################COptions			= -fa -zps0 -za1 -i "{ExamplesLibDir}"CDebugOptions		= -g -d DEBUG={DebugFlag}LOptions			= -aif -r -b 0x00LStackSize			= 4096LDebugOptions		= -dModbinDebugOptions	= -debug######################################		Object files#####################################OBJECTS			=	{ObjectDir}{App}.c.o ¶					"{3DOLibs}"cstartup.oLIBS			=	¶					"{ExamplesLibDir}ExamplesLib.lib"  ¶					"{3DOLibs}Lib3DO.lib" ¶					"{3DOLibs}audio.lib" ¶					"{3DOLibs}music.lib" ¶					"{3DOLibs}operamath.lib" ¶					"{3DOLibs}filesystem.lib" ¶					"{3DOLibs}graphics.lib" ¶					"{3DOLibs}input.lib" ¶					"{3DOLibs}clib.lib"					######################################	Default build rules#####################################All				Ä	{App}{ObjectDir}		Ä	:.c.o	Ä	.c	{CC} -i "{3DOIncludes}" {COptions} {CDebugOptions} -o {TargDir}{Default}.c.o {DepDir}{Default}.c######################################	Target build rules#####################################{App} Ä {App}.make {OBJECTS}	{LINK} {LOptions} {LDebugOptions} ¶		{OBJECTS} ¶		{LIBS} ¶		-o "{WorkingDisk}"{Targ}	SetFile "{WorkingDisk}"{Targ} -c 'EaDJ' -t 'PROJ'	modbin "{WorkingDisk}"{Targ} -stack {LStackSize} {ModbinDebugOptions}	stripaif "{WorkingDisk}"{Targ} -o {Targ} -s {Targ}.sym	if not `exists "{AppsDir}"`		newFolder "{AppsDir}"	end	move -y {Targ} "{AppsDir}"	move -y {Targ}.sym "{AppsDir}"######################################	Include file dependencies#####################################{ObjectDir}{App}.c.o			Ä	{App}.make jsbasicslideshow.h
+
+#####################################
+##
+## Copyright (C) 1995, an unpublished work by The 3DO Company. All rights reserved.
+## This material contains confidential information that is the property of The 3DO Company.
+## Any unauthorized duplication, disclosure or use is prohibited.
+## $Id: jsbasicslideshow.make,v 1.7 1995/01/20 04:57:12 ceckhaus Exp $
+##
+#####################################
+
+#   File:       jsbasicslideshow.make
+#   Target:     jsbasicslideshow
+#   Sources:    jsbasicslideshow.c
+#
+
+#####################################
+#		Symbol definitions
+#####################################
+
+App				=	jsbasicslideshow
+DebugFlag		=	1
+ObjectDir		=	:Objects:
+SourceDir		=	:
+AppsDir			=	:Apps_Data:
+ExamplesLibDir	=	{3DOFolder}Examples:ExamplesLib:
+CC				=	armcc
+LINK			=	armlink
+WorkingDisk		= 
+
+#####################################
+#	Default compiler options
+#####################################
+
+COptions			= -fa -zps0 -za1 -i "{ExamplesLibDir}"
+CDebugOptions		= -g -d DEBUG={DebugFlag}
+LOptions			= -aif -r -b 0x00
+LStackSize			= 4096
+LDebugOptions		= -d
+ModbinDebugOptions	= -debug
+
+#####################################
+#		Object files
+#####################################
+
+OBJECTS			=	{ObjectDir}{App}.c.o âˆ‚
+					"{3DOLibs}"cstartup.o
+
+LIBS			=	âˆ‚
+					"{ExamplesLibDir}ExamplesLib.lib"  âˆ‚
+					"{3DOLibs}Lib3DO.lib" âˆ‚
+					"{3DOLibs}audio.lib" âˆ‚
+					"{3DOLibs}music.lib" âˆ‚
+					"{3DOLibs}operamath.lib" âˆ‚
+					"{3DOLibs}filesystem.lib" âˆ‚
+					"{3DOLibs}graphics.lib" âˆ‚
+					"{3DOLibs}input.lib" âˆ‚
+					"{3DOLibs}clib.lib"
+					
+#####################################
+#	Default build rules
+#####################################
+
+All				Æ’	{App}
+
+{ObjectDir}		Æ’	:
+
+.c.o	Æ’	.c
+	{CC} -i "{3DOIncludes}" {COptions} {CDebugOptions} -o {TargDir}{Default}.c.o {DepDir}{Default}.c
+
+#####################################
+#	Target build rules
+#####################################
+
+{App} Æ’ {App}.make {OBJECTS}
+	{LINK} {LOptions} {LDebugOptions} âˆ‚
+		{OBJECTS} âˆ‚
+		{LIBS} âˆ‚
+		-o "{WorkingDisk}"{Targ}
+	SetFile "{WorkingDisk}"{Targ} -c 'EaDJ' -t 'PROJ'
+	modbin "{WorkingDisk}"{Targ} -stack {LStackSize} {ModbinDebugOptions}
+	stripaif "{WorkingDisk}"{Targ} -o {Targ} -s {Targ}.sym
+	if not `exists "{AppsDir}"`
+		newFolder "{AppsDir}"
+	end
+	move -y {Targ} "{AppsDir}"
+	move -y {Targ}.sym "{AppsDir}"
+
+#####################################
+#	Include file dependencies
+#####################################
+
+{ObjectDir}{App}.c.o			Æ’	{App}.make jsbasicslideshow.h
+

--- a/release/examples/Jumpstart/Jumpstart2/Jumpstart_Slideshow/jsslideshowvdl.make
+++ b/release/examples/Jumpstart/Jumpstart2/Jumpstart_Slideshow/jsslideshowvdl.make
@@ -1,1 +1,94 @@
-######################################### Copyright (C) 1995, an unpublished work by The 3DO Company. All rights reserved.## This material contains confidential information that is the property of The 3DO Company.## Any unauthorized duplication, disclosure or use is prohibited.## $Id: jsslideshowvdl.make,v 1.7 1995/01/20 04:57:12 ceckhaus Exp $#########################################   File:       jsslideshowvdl.make#   Target:     jsslideshowvdl#   Sources:    jsslideshowvdl.c#######################################		Symbol definitions#####################################App				=	jsslideshowvdlDebugFlag		=	1ObjectDir		=	:Objects:SourceDir		=	:AppsDir			=	:Apps_Data:ExamplesLibDir	=	{3DOFolder}Examples:ExamplesLib:CC				=	armccLINK			=	armlinkWorkingDisk		= ######################################	Default compiler options#####################################COptions			= -fa -zps0 -za1 -i "{ExamplesLibDir}"CDebugOptions		= -g -d DEBUG={DebugFlag}LOptions			= -aif -r -b 0x00LStackSize			= 4096LDebugOptions		= -dModbinDebugOptions	= -debug######################################		Object files#####################################OBJECTS			=	{ObjectDir}{App}.c.o ¶					"{3DOLibs}"cstartup.oLIBS			=	¶					"{ExamplesLibDir}ExamplesLib.lib"  ¶					"{3DOLibs}Lib3DO.lib" ¶					"{3DOLibs}audio.lib" ¶					"{3DOLibs}music.lib" ¶					"{3DOLibs}operamath.lib" ¶					"{3DOLibs}filesystem.lib" ¶					"{3DOLibs}graphics.lib" ¶					"{3DOLibs}input.lib" ¶					"{3DOLibs}clib.lib"					######################################	Default build rules#####################################All				Ä	{App}{ObjectDir}		Ä	:.c.o	Ä	.c	{CC} -i "{3DOIncludes}" {COptions} {CDebugOptions} -o {TargDir}{Default}.c.o {DepDir}{Default}.c######################################	Target build rules#####################################{App} Ä {App}.make {OBJECTS}	{LINK} {LOptions} {LDebugOptions} ¶		{OBJECTS} ¶		{LIBS} ¶		-o "{WorkingDisk}"{Targ}	SetFile "{WorkingDisk}"{Targ} -c 'EaDJ' -t 'PROJ'	modbin "{WorkingDisk}"{Targ} -stack {LStackSize} {ModbinDebugOptions}	stripaif "{WorkingDisk}"{Targ} -o {Targ} -s {Targ}.sym	if not `exists "{AppsDir}"`		newFolder "{AppsDir}"	end	move -y {Targ} "{AppsDir}"	move -y {Targ}.sym "{AppsDir}"######################################	Include file dependencies#####################################{ObjectDir}{App}.c.o			Ä	{App}.make {App}.h
+
+#####################################
+##
+## Copyright (C) 1995, an unpublished work by The 3DO Company. All rights reserved.
+## This material contains confidential information that is the property of The 3DO Company.
+## Any unauthorized duplication, disclosure or use is prohibited.
+## $Id: jsslideshowvdl.make,v 1.7 1995/01/20 04:57:12 ceckhaus Exp $
+##
+#####################################
+
+#
+#   File:       jsslideshowvdl.make
+#   Target:     jsslideshowvdl
+#   Sources:    jsslideshowvdl.c
+#
+
+#####################################
+#		Symbol definitions
+#####################################
+
+App				=	jsslideshowvdl
+DebugFlag		=	1
+ObjectDir		=	:Objects:
+SourceDir		=	:
+AppsDir			=	:Apps_Data:
+ExamplesLibDir	=	{3DOFolder}Examples:ExamplesLib:
+CC				=	armcc
+LINK			=	armlink
+WorkingDisk		= 
+
+#####################################
+#	Default compiler options
+#####################################
+
+COptions			= -fa -zps0 -za1 -i "{ExamplesLibDir}"
+CDebugOptions		= -g -d DEBUG={DebugFlag}
+LOptions			= -aif -r -b 0x00
+LStackSize			= 4096
+LDebugOptions		= -d
+ModbinDebugOptions	= -debug
+
+#####################################
+#		Object files
+#####################################
+
+OBJECTS			=	{ObjectDir}{App}.c.o âˆ‚
+					"{3DOLibs}"cstartup.o
+
+LIBS			=	âˆ‚
+					"{ExamplesLibDir}ExamplesLib.lib"  âˆ‚
+					"{3DOLibs}Lib3DO.lib" âˆ‚
+					"{3DOLibs}audio.lib" âˆ‚
+					"{3DOLibs}music.lib" âˆ‚
+					"{3DOLibs}operamath.lib" âˆ‚
+					"{3DOLibs}filesystem.lib" âˆ‚
+					"{3DOLibs}graphics.lib" âˆ‚
+					"{3DOLibs}input.lib" âˆ‚
+					"{3DOLibs}clib.lib"
+					
+#####################################
+#	Default build rules
+#####################################
+
+All				Æ’	{App}
+
+{ObjectDir}		Æ’	:
+
+.c.o	Æ’	.c
+	{CC} -i "{3DOIncludes}" {COptions} {CDebugOptions} -o {TargDir}{Default}.c.o {DepDir}{Default}.c
+
+
+#####################################
+#	Target build rules
+#####################################
+
+{App} Æ’ {App}.make {OBJECTS}
+	{LINK} {LOptions} {LDebugOptions} âˆ‚
+		{OBJECTS} âˆ‚
+		{LIBS} âˆ‚
+		-o "{WorkingDisk}"{Targ}
+	SetFile "{WorkingDisk}"{Targ} -c 'EaDJ' -t 'PROJ'
+	modbin "{WorkingDisk}"{Targ} -stack {LStackSize} {ModbinDebugOptions}
+	stripaif "{WorkingDisk}"{Targ} -o {Targ} -s {Targ}.sym
+	if not `exists "{AppsDir}"`
+		newFolder "{AppsDir}"
+	end
+	move -y {Targ} "{AppsDir}"
+	move -y {Targ}.sym "{AppsDir}"
+
+#####################################
+#	Include file dependencies
+#####################################
+
+{ObjectDir}{App}.c.o			Æ’	{App}.make {App}.h

--- a/release/examples/Jumpstart/UFO/playbgndmusic.make
+++ b/release/examples/Jumpstart/UFO/playbgndmusic.make
@@ -1,1 +1,97 @@
-######################################### Copyright (C) 1995, an unpublished work by The 3DO Company. All rights reserved.## This material contains confidential information that is the property of The 3DO Company.## Any unauthorized duplication, disclosure or use is prohibited.## $Id: playbgndmusic.make,v 1.11 1995/02/06 19:46:58 limes Exp $#########################################   File:       playbgndmusic.make#   Target:     playbgndmusic#   Sources:    playbgndmusic.c##   Copyright (c) 1995, The 3DO Company#   All rights reserved.#######################################	Symbol definitions#####################################App				=	playbgndmusicDebugFlag		=	1ObjectDir		=	:Objects:SourceDir		=	:AppsDir			=	:Apps_Data:ExamplesLibDir	=	{3DOFolder}Examples:ExamplesLib:CC				=	armccLINK			=	armlinkWorkingDisk		=######################################	Default compiler options#####################################COptions			= -fa -zps0 -za1 -i "{ExamplesLibDir}"CDebugOptions		= -g -d DEBUG={DebugFlag}LOptions			= -aif -r -b 0x00LStackSize			= 4096LDebugOptions		= -dModbinDebugOptions	= -debug######################################	Object files#####################################OBJECTS			=	{ObjectDir}{App}.c.o ¶					"{3DOLibs}"cstartup.oLIBS			=	 ¶					"{ExamplesLibDir}ExamplesLib.lib"  ¶					"{3DOLibs}Lib3DO.lib" ¶					"{3DOLibs}audio.lib" ¶					"{3DOLibs}music.lib" ¶					"{3DOLibs}operamath.lib" ¶					"{3DOLibs}filesystem.lib" ¶					"{3DOLibs}graphics.lib" ¶					"{3DOLibs}input.lib" ¶					"{3DOLibs}clib.lib"######################################	Default build rules#####################################All				Ä	{App}{ObjectDir}		Ä	:.c.o	Ä	.c	{CC} -i "{3DOIncludes}" {COptions} {CDebugOptions} -o {TargDir}{Default}.c.o {DepDir}{Default}.c######################################	Target build rules#####################################{App} Ä {App}.make {OBJECTS}	{LINK} {LOptions} {LDebugOptions} ¶		{OBJECTS} ¶		{LIBS} ¶		-o "{WorkingDisk}"{Targ}	SetFile "{WorkingDisk}"{Targ} -c 'EaDJ' -t 'PROJ'	modbin "{WorkingDisk}"{Targ} -stack {LStackSize} {ModbinDebugOptions}	stripaif "{WorkingDisk}"{Targ} -o {Targ} -s {Targ}.sym	SetVersion "{WorkingDisk}"{Targ} -t vers -i 1 -sv 2 -sr 0  -verstring ' ^, © 3DO Company 1994'	if not `exists "{AppsDir}"`		newFolder "{AppsDir}"	end	move -y {Targ} "{AppsDir}"	move -y {Targ}.sym "{AppsDir}"######################################	Additional Target Dependencies#####################################{ObjectDir}{App}.c.o			Ä	{App}.make
+#####################################
+##
+## Copyright (C) 1995, an unpublished work by The 3DO Company. All rights reserved.
+## This material contains confidential information that is the property of The 3DO Company.
+## Any unauthorized duplication, disclosure or use is prohibited.
+## $Id: playbgndmusic.make,v 1.11 1995/02/06 19:46:58 limes Exp $
+##
+#####################################
+#
+#   File:       playbgndmusic.make
+#   Target:     playbgndmusic
+#   Sources:    playbgndmusic.c
+#
+#   Copyright (c) 1995, The 3DO Company
+#   All rights reserved.
+#
+
+#####################################
+#	Symbol definitions
+#####################################
+
+App				=	playbgndmusic
+DebugFlag		=	1
+ObjectDir		=	:Objects:
+SourceDir		=	:
+AppsDir			=	:Apps_Data:
+ExamplesLibDir	=	{3DOFolder}Examples:ExamplesLib:
+CC				=	armcc
+LINK			=	armlink
+WorkingDisk		=
+
+#####################################
+#	Default compiler options
+#####################################
+
+COptions			= -fa -zps0 -za1 -i "{ExamplesLibDir}"
+CDebugOptions		= -g -d DEBUG={DebugFlag}
+LOptions			= -aif -r -b 0x00
+LStackSize			= 4096
+LDebugOptions		= -d
+ModbinDebugOptions	= -debug
+
+#####################################
+#	Object files
+#####################################
+
+OBJECTS			=	{ObjectDir}{App}.c.o âˆ‚
+					"{3DOLibs}"cstartup.o
+
+LIBS			=	 âˆ‚
+					"{ExamplesLibDir}ExamplesLib.lib"  âˆ‚
+					"{3DOLibs}Lib3DO.lib" âˆ‚
+					"{3DOLibs}audio.lib" âˆ‚
+					"{3DOLibs}music.lib" âˆ‚
+					"{3DOLibs}operamath.lib" âˆ‚
+					"{3DOLibs}filesystem.lib" âˆ‚
+					"{3DOLibs}graphics.lib" âˆ‚
+					"{3DOLibs}input.lib" âˆ‚
+					"{3DOLibs}clib.lib"
+
+#####################################
+#	Default build rules
+#####################################
+
+All				Æ’	{App}
+
+{ObjectDir}		Æ’	:
+
+.c.o	Æ’	.c
+	{CC} -i "{3DOIncludes}" {COptions} {CDebugOptions} -o {TargDir}{Default}.c.o {DepDir}{Default}.c
+
+#####################################
+#	Target build rules
+#####################################
+
+{App} Æ’ {App}.make {OBJECTS}
+	{LINK} {LOptions} {LDebugOptions} âˆ‚
+		{OBJECTS} âˆ‚
+		{LIBS} âˆ‚
+		-o "{WorkingDisk}"{Targ}
+	SetFile "{WorkingDisk}"{Targ} -c 'EaDJ' -t 'PROJ'
+	modbin "{WorkingDisk}"{Targ} -stack {LStackSize} {ModbinDebugOptions}
+	stripaif "{WorkingDisk}"{Targ} -o {Targ} -s {Targ}.sym
+	SetVersion "{WorkingDisk}"{Targ} -t vers -i 1 -sv 2 -sr 0  -verstring ' ^, Â© 3DO Company 1994'
+	if not `exists "{AppsDir}"`
+		newFolder "{AppsDir}"
+	end
+	move -y {Targ} "{AppsDir}"
+	move -y {Targ}.sym "{AppsDir}"
+
+
+#####################################
+#	Additional Target Dependencies
+#####################################
+
+{ObjectDir}{App}.c.o			Æ’	{App}.make
+

--- a/release/examples/Jumpstart/UFO/ufo.make
+++ b/release/examples/Jumpstart/UFO/ufo.make
@@ -1,1 +1,93 @@
-######################################### Copyright (C) 1995, an unpublished work by The 3DO Company. All rights reserved.## This material contains confidential information that is the property of The 3DO Company.## Any unauthorized duplication, disclosure or use is prohibited.## $Id: ufo.make,v 1.10 1995/01/20 04:57:40 ceckhaus Exp $########################################   File:       ufo.make#   Target:     ufo#   Sources:    ufo.c#######################################	Symbol definitions#####################################App				= ufoDebugFlag		= 1ObjectDir		= :Objects:SourceDir		= :AppsDir			= :Apps_Data:ExamplesLibDir	= {3DOFolder}Examples:ExamplesLib:CC				= armccLINK			= armlinkWorkingDisk		= ######################################	Default compiler options#####################################COptions			= -fa -zps0 -za1 -i "{ExamplesLibDir}"CDebugOptions		= -g -d DEBUG={DebugFlag}LOptions			= -aif -r -b 0x00LStackSize			= 4096LDebugOptions		= -dModbinDebugOptions	= -debug######################################	Object files#####################################OBJECTS			=	 {ObjectDir}{App}.c.o ¶					"{3DOLibs}"cstartup.oLIBS			=	 ¶					"{ExamplesLibDir}ExamplesLib.lib"  ¶					"{3DOLibs}Lib3DO.lib" ¶					"{3DOLibs}audio.lib" ¶					"{3DOLibs}music.lib" ¶					"{3DOLibs}operamath.lib" ¶					"{3DOLibs}filesystem.lib" ¶					"{3DOLibs}graphics.lib" ¶					"{3DOLibs}input.lib" ¶					"{3DOLibs}clib.lib"######################################	Default build rules#####################################All				Ä	{App}{ObjectDir}		Ä	:.c.o	Ä	.c	{CC} -i "{3DOIncludes}" {COptions} {CDebugOptions} -o {TargDir}{Default}.c.o {DepDir}{Default}.c######################################	Target build rules#####################################{App} Ä {App}.make {OBJECTS}	{LINK} {LOptions} {LDebugOptions} ¶		{OBJECTS} ¶		{LIBS} ¶		-o "{WorkingDisk}"{Targ}	SetFile "{WorkingDisk}"{Targ} -c 'EaDJ' -t 'PROJ'	modbin "{WorkingDisk}"{Targ} -stack {LStackSize} {ModbinDebugOptions}	stripaif "{WorkingDisk}"{Targ} -o {Targ} -s {Targ}.sym	if not `exists "{AppsDir}"`		newFolder "{AppsDir}"	end	move -y {Targ} "{AppsDir}"	move -y {Targ}.sym "{AppsDir}"######################################	Additional Target Dependencies#####################################{ObjectDir}{App}.c.o		Ä	{App}.make
+
+#####################################
+##
+## Copyright (C) 1995, an unpublished work by The 3DO Company. All rights reserved.
+## This material contains confidential information that is the property of The 3DO Company.
+## Any unauthorized duplication, disclosure or use is prohibited.
+## $Id: ufo.make,v 1.10 1995/01/20 04:57:40 ceckhaus Exp $
+##
+#####################################
+
+#   File:       ufo.make
+#   Target:     ufo
+#   Sources:    ufo.c
+#
+
+#####################################
+#	Symbol definitions
+#####################################
+
+App				= ufo
+DebugFlag		= 1
+ObjectDir		= :Objects:
+SourceDir		= :
+AppsDir			= :Apps_Data:
+ExamplesLibDir	= {3DOFolder}Examples:ExamplesLib:
+CC				= armcc
+LINK			= armlink
+WorkingDisk		= 
+
+#####################################
+#	Default compiler options
+#####################################
+
+COptions			= -fa -zps0 -za1 -i "{ExamplesLibDir}"
+CDebugOptions		= -g -d DEBUG={DebugFlag}
+LOptions			= -aif -r -b 0x00
+LStackSize			= 4096
+LDebugOptions		= -d
+ModbinDebugOptions	= -debug
+
+#####################################
+#	Object files
+#####################################
+
+OBJECTS			=	 {ObjectDir}{App}.c.o âˆ‚
+					"{3DOLibs}"cstartup.o
+
+LIBS			=	 âˆ‚
+					"{ExamplesLibDir}ExamplesLib.lib"  âˆ‚
+					"{3DOLibs}Lib3DO.lib" âˆ‚
+					"{3DOLibs}audio.lib" âˆ‚
+					"{3DOLibs}music.lib" âˆ‚
+					"{3DOLibs}operamath.lib" âˆ‚
+					"{3DOLibs}filesystem.lib" âˆ‚
+					"{3DOLibs}graphics.lib" âˆ‚
+					"{3DOLibs}input.lib" âˆ‚
+					"{3DOLibs}clib.lib"
+
+#####################################
+#	Default build rules
+#####################################
+
+All				Æ’	{App}
+
+{ObjectDir}		Æ’	:
+
+.c.o	Æ’	.c
+	{CC} -i "{3DOIncludes}" {COptions} {CDebugOptions} -o {TargDir}{Default}.c.o {DepDir}{Default}.c
+
+#####################################
+#	Target build rules
+#####################################
+
+{App} Æ’ {App}.make {OBJECTS}
+	{LINK} {LOptions} {LDebugOptions} âˆ‚
+		{OBJECTS} âˆ‚
+		{LIBS} âˆ‚
+		-o "{WorkingDisk}"{Targ}
+	SetFile "{WorkingDisk}"{Targ} -c 'EaDJ' -t 'PROJ'
+	modbin "{WorkingDisk}"{Targ} -stack {LStackSize} {ModbinDebugOptions}
+	stripaif "{WorkingDisk}"{Targ} -o {Targ} -s {Targ}.sym
+	if not `exists "{AppsDir}"`
+		newFolder "{AppsDir}"
+	end
+	move -y {Targ} "{AppsDir}"
+	move -y {Targ}.sym "{AppsDir}"
+
+#####################################
+#	Additional Target Dependencies
+#####################################
+
+{ObjectDir}{App}.c.o		Æ’	{App}.make
+

--- a/release/examples/Kernel/kernel.make
+++ b/release/examples/Kernel/kernel.make
@@ -1,1 +1,84 @@
-######################################### Copyright (C) 1995, an unpublished work by The 3DO Company. All rights reserved.## This material contains confidential information that is the property of The 3DO Company.## Any unauthorized duplication, disclosure or use is prohibited.## $Id: kernel.make,v 1.3 1995/01/19 02:10:54 mattm Exp $########################################   File:       kernel.make#   Target:     allocmem memdebug msgpassing signals timerread timersleep#   Sources:    allocmem.c memdebug.c msgpassing.c signals.c timerread.c timersleep.c##   Copyright (c) 1995, The 3DO Company#   All rights reserved.#######################################	Symbol definitions#####################################App				= KernelDebugFlag		= 1SourceDir		= {3DOFolder}Examples:Kernel:ObjectDir		= :Objects:ExecutableDir	= {SourceDir}Apps_Data:TempDir			= :CC				= armccLINK			= armlink######################################	Default compiler options#####################################COptions			= -fa -zps0 -za1CDebugOptions		= -g -d DEBUG={DebugFlag}LOptions			= -aif -r -b 0x00 -workspace 0x10000LStackSize			= 6000LDebugOptions		= -dModbinDebugOptions	= -debug######################################	Object files#####################################OBJECTS			=	{ObjectDir}allocmem.c.o		¶					{ObjectDir}memdebug.c.o		¶					{ObjectDir}msgpassing.c.o	¶					{ObjectDir}signals.c.o		¶					{ObjectDir}timerread.c.o	¶					{ObjectDir}timersleep.c.o					LIBS			=	"{3DOLibs}Lib3DO.lib" ¶					"{3DOLibs}audio.lib" ¶					"{3DOLibs}music.lib" ¶					"{3DOLibs}operamath.lib" ¶					"{3DOLibs}filesystem.lib" ¶					"{3DOLibs}graphics.lib" ¶					"{3DOLibs}input.lib" ¶					"{3DOLibs}memdebug.lib" ¶					"{3DOLibs}clib.lib"					######################################	Default build rules#####################################All				Ä	{App}{ObjectDir}		Ä	:.c.o	Ä	.c	{CC} -i "{3DOIncludes}" {COptions} {CDebugOptions} -o {TargDir}{Default}.c.o {DepDir}{Default}.c	{LINK} {LOptions} {LDebugOptions} ¶		{TargDir}{Default}.c.o ¶		"{3DOLibs}"cstartup.o ¶		{LIBS} ¶		-o {TempDir}{Default}.nostrip	SetFile {TempDir}{Default}.nostrip -c 'EaDJ' -t 'PROJ'	modbin {TempDir}{Default}.nostrip -stack {LStackSize} {ModbinDebugOptions}	stripaif {TempDir}{Default}.nostrip -o {ExecutableDir}{Default} -s {ExecutableDir}{Default}.sym	delete {TempDir}{Default}.nostrip{App} Ä {App}.make {OBJECTS}
+#####################################
+##
+## Copyright (C) 1995, an unpublished work by The 3DO Company. All rights reserved.
+## This material contains confidential information that is the property of The 3DO Company.
+## Any unauthorized duplication, disclosure or use is prohibited.
+## $Id: kernel.make,v 1.3 1995/01/19 02:10:54 mattm Exp $
+##
+#####################################
+#   File:       kernel.make
+#   Target:     allocmem memdebug msgpassing signals timerread timersleep
+#   Sources:    allocmem.c memdebug.c msgpassing.c signals.c timerread.c timersleep.c
+#
+#   Copyright (c) 1995, The 3DO Company
+#   All rights reserved.
+#
+
+#####################################
+#	Symbol definitions
+#####################################
+
+App				= Kernel
+DebugFlag		= 1
+
+SourceDir		= {3DOFolder}Examples:Kernel:
+ObjectDir		= :Objects:
+ExecutableDir	= {SourceDir}Apps_Data:
+TempDir			= :
+
+CC				= armcc
+LINK			= armlink
+
+#####################################
+#	Default compiler options
+#####################################
+
+COptions			= -fa -zps0 -za1
+CDebugOptions		= -g -d DEBUG={DebugFlag}
+LOptions			= -aif -r -b 0x00 -workspace 0x10000
+LStackSize			= 6000
+LDebugOptions		= -d
+ModbinDebugOptions	= -debug
+
+#####################################
+#	Object files
+#####################################
+
+OBJECTS			=	{ObjectDir}allocmem.c.o		âˆ‚
+					{ObjectDir}memdebug.c.o		âˆ‚
+					{ObjectDir}msgpassing.c.o	âˆ‚
+					{ObjectDir}signals.c.o		âˆ‚
+					{ObjectDir}timerread.c.o	âˆ‚
+					{ObjectDir}timersleep.c.o
+					
+LIBS			=	"{3DOLibs}Lib3DO.lib" âˆ‚
+					"{3DOLibs}audio.lib" âˆ‚
+					"{3DOLibs}music.lib" âˆ‚
+					"{3DOLibs}operamath.lib" âˆ‚
+					"{3DOLibs}filesystem.lib" âˆ‚
+					"{3DOLibs}graphics.lib" âˆ‚
+					"{3DOLibs}input.lib" âˆ‚
+					"{3DOLibs}memdebug.lib" âˆ‚
+					"{3DOLibs}clib.lib"
+					
+#####################################
+#	Default build rules
+#####################################
+
+All				Æ’	{App}
+
+{ObjectDir}		Æ’	:
+
+.c.o	Æ’	.c
+	{CC} -i "{3DOIncludes}" {COptions} {CDebugOptions} -o {TargDir}{Default}.c.o {DepDir}{Default}.c
+	{LINK} {LOptions} {LDebugOptions} âˆ‚
+		{TargDir}{Default}.c.o âˆ‚
+		"{3DOLibs}"cstartup.o âˆ‚
+		{LIBS} âˆ‚
+		-o {TempDir}{Default}.nostrip
+	SetFile {TempDir}{Default}.nostrip -c 'EaDJ' -t 'PROJ'
+	modbin {TempDir}{Default}.nostrip -stack {LStackSize} {ModbinDebugOptions}
+	stripaif {TempDir}{Default}.nostrip -o {ExecutableDir}{Default} -s {ExecutableDir}{Default}.sym
+	delete {TempDir}{Default}.nostrip
+
+{App} Æ’ {App}.make {OBJECTS}

--- a/release/examples/Lib3DO/Lib3DO.lib.make
+++ b/release/examples/Lib3DO/Lib3DO.lib.make
@@ -1,1 +1,166 @@
-######################################### Copyright (C) 1995, an unpublished work by The 3DO Company. All rights reserved.## This material contains confidential information that is the property of The 3DO Company.## Any unauthorized duplication, disclosure or use is prohibited.## $Id: Lib3DO.lib.make,v 1.4 1995/02/20 23:42:10 stan Exp $########################################   File:       Lib3DO.lib.make#   Target:     Lib3DO.lib#   Sources:##   Copyright (c) 1994, The 3DO Company#   All rights reserved.#######################################		Symbol definitions#####################################Library			= 	Lib3DO.libDebugFlag		=	1Version			=	1.5a12######################################	Default compiler options#####################################CDebugOptions	= -d DEBUG={DebugFlag} # -gCOptions		= {CDebugOptions} -zps0 -zpv1 -za1 -fa -fh -fk -i ":Includes:" -i "{3DOIncludes}"SOptions		= -bi -g -i "{3DOIncludes}"LOptions		= -c -o######################################		Object files#####################################ObjectDir		=	:Objects:"{ObjectDir}"	Ä	¶					:AnimUtils:								¶					:CelUtils:								¶					:DisplayUtils:							¶					:IOUtils:								¶					:MiscUtils:								¶					:Objects:								¶					:TimerUtils:							¶					:TextLib:								¶AnimUtils =			¶					"{ObjectDir}DrawAnimCel.c.o"			¶					"{ObjectDir}GetAnimCel.c.o"				¶					"{ObjectDir}LoadAnim.c.o"				¶					"{ObjectDir}ParseAnim.c.o"				¶CelUtils =			¶					"{ObjectDir}CenterPoint.c.o"			¶					"{ObjectDir}CenterRect.c.o"				¶					"{ObjectDir}CenterRectCelIPoint.c.o"	¶					"{ObjectDir}CenterRectCelFPoint.c.o"	¶					"{ObjectDir}CenterRectCelRect.c.o"		¶					"{ObjectDir}ChainCels.c.o" 				¶					"{ObjectDir}CloneCel.c.o" 				¶					"{ObjectDir}CreateBackdropCel.c.o"	 	¶					"{ObjectDir}CreateCel.c.o" 				¶					"{ObjectDir}CreateLRFormCel.c.o" 		¶					"{ObjectDir}CreateSubrectCel.c.o" 		¶					"{ObjectDir}CrossFadeCels.c.o"			¶					"{ObjectDir}DeleteCelMagic.c.o" 		¶					"{ObjectDir}GetCelBufferSize.c.o"		¶					"{ObjectDir}InitCel.c.o"				¶					"{ObjectDir}InterUnionRect.c.o"			¶					"{ObjectDir}LinkCel.c.o"				¶					"{ObjectDir}LoadCel.c.o" 				¶					"{ObjectDir}MapCelToPoint.c.o"			¶					"{ObjectDir}MapCelToRect.c.o" 			¶					"{ObjectDir}MapCelToQuad.c.o" 			¶					"{ObjectDir}OffsetInsetRect.c.o"		¶					"{ObjectDir}OffsetCel.c.o"	 			¶					"{ObjectDir}ParseCel.c.o" 				¶					"{ObjectDir}PointConversions.c.o"		¶					"{ObjectDir}RectConversions.c.o" 		¶					"{ObjectDir}RectFromCel.c.o"			¶					"{ObjectDir}RenderCelPixel.c.o"			¶DisplayUtils =		¶					"{ObjectDir}ClearBitmap.c.o"			¶					"{ObjectDir}DrawImage.c.o"				¶					"{ObjectDir}LoadImage.c.o"				¶					"{ObjectDir}FadeFromBlack.c.o"			¶					"{ObjectDir}FadeToBlack.c.o"			¶					"{ObjectDir}CreateBasicDisplay.c.o"			¶IOUtils =			¶					"{ObjectDir}AsyncLoadFile.c.o"			¶					"{ObjectDir}BlockFile.c.o"				¶					"{ObjectDir}GetFileSize.c.o"			¶					"{ObjectDir}LoadFile.c.o"				¶					"{ObjectDir}ReadFile.c.o"				¶					"{ObjectDir}SaveFile.c.o"				¶					"{ObjectDir}WriteMacFile.c.o"			¶MiscUtils =			¶					"{ObjectDir}Debug3DO.c.o"				¶					"{ObjectDir}GetChunk.c.o"				¶					"{ObjectDir}UMemory.c.o"				¶					"{ObjectDir}MSEvents.c.o"				¶TimerUtils =			¶					"{ObjectDir}TimerServicesAPI.c.o"		¶					"{ObjectDir}TimerServicesAPIU.c.o"		¶					"{ObjectDir}TimerServicesAPIV.c.o"		¶					"{ObjectDir}TimerServicesThread.c.o"	¶					"{ObjectDir}TimerUtilsGetIOReq.c.o"		¶					"{ObjectDir}TimerUtilsGetTime.c.o"		¶					"{ObjectDir}TimerUtilsSleep.c.o"		¶TextLib =			¶					"{ObjectDir}taTextLib.c.o"				¶					"{ObjectDir}FontBlit3To8_.s.o"			¶					"{ObjectDir}FontBlit5To8_.s.o"			¶					"{ObjectDir}FontLib.c.o"				¶					"{ObjectDir}TextLib.c.o"				¶OBJECTS			=	¶					{AnimUtils}								¶					{CelUtils}								¶					{DisplayUtils}							¶					{IOUtils}								¶					{MiscUtils}								¶					{TimerUtils}							¶					{TextLib}								¶######################################	Default build rules#####################################CC				=	armccASM				=	armasmLIBRARIAN		=	armlib.c.o			Ä	.c	{CC}  {DepDir}{Default}.c {COptions} -o {TargDir}{Default}.c.o.s.o			Ä	.s	{ASM} {DepDir}{Default}.s {SOptions} -o {TargDir}{Default}.s.o######################################	Primary target build rules#####################################"{Library}"		Ä {OBJECTS}	{LIBRARIAN}	{LOptions} "{Library}" {OBJECTS}	SetVersion  "{Library}" -t 'vers' -version {Version}	Duplicate -y "{Library}" "{3DOLibs}{Library}"
+#####################################
+##
+## Copyright (C) 1995, an unpublished work by The 3DO Company. All rights reserved.
+## This material contains confidential information that is the property of The 3DO Company.
+## Any unauthorized duplication, disclosure or use is prohibited.
+## $Id: Lib3DO.lib.make,v 1.4 1995/02/20 23:42:10 stan Exp $
+##
+#####################################
+#   File:       Lib3DO.lib.make
+#   Target:     Lib3DO.lib
+#   Sources:
+#
+#   Copyright (c) 1994, The 3DO Company
+#   All rights reserved.
+#
+
+#####################################
+#		Symbol definitions
+#####################################
+
+Library			= 	Lib3DO.lib
+DebugFlag		=	1
+Version			=	1.5a12
+
+#####################################
+#	Default compiler options
+#####################################
+
+CDebugOptions	= -d DEBUG={DebugFlag} # -g
+
+COptions		= {CDebugOptions} -zps0 -zpv1 -za1 -fa -fh -fk -i ":Includes:" -i "{3DOIncludes}"
+
+SOptions		= -bi -g -i "{3DOIncludes}"
+
+LOptions		= -c -o
+
+#####################################
+#		Object files
+#####################################
+
+ObjectDir		=	:Objects:
+
+"{ObjectDir}"	Æ’	âˆ‚
+					:AnimUtils:								âˆ‚
+					:CelUtils:								âˆ‚
+					:DisplayUtils:							âˆ‚
+					:IOUtils:								âˆ‚
+					:MiscUtils:								âˆ‚
+					:Objects:								âˆ‚
+					:TimerUtils:							âˆ‚
+					:TextLib:								âˆ‚
+
+AnimUtils =			âˆ‚
+					"{ObjectDir}DrawAnimCel.c.o"			âˆ‚
+					"{ObjectDir}GetAnimCel.c.o"				âˆ‚
+					"{ObjectDir}LoadAnim.c.o"				âˆ‚
+					"{ObjectDir}ParseAnim.c.o"				âˆ‚
+
+
+CelUtils =			âˆ‚
+					"{ObjectDir}CenterPoint.c.o"			âˆ‚
+					"{ObjectDir}CenterRect.c.o"				âˆ‚
+					"{ObjectDir}CenterRectCelIPoint.c.o"	âˆ‚
+					"{ObjectDir}CenterRectCelFPoint.c.o"	âˆ‚
+					"{ObjectDir}CenterRectCelRect.c.o"		âˆ‚
+					"{ObjectDir}ChainCels.c.o" 				âˆ‚
+					"{ObjectDir}CloneCel.c.o" 				âˆ‚
+					"{ObjectDir}CreateBackdropCel.c.o"	 	âˆ‚
+					"{ObjectDir}CreateCel.c.o" 				âˆ‚
+					"{ObjectDir}CreateLRFormCel.c.o" 		âˆ‚
+					"{ObjectDir}CreateSubrectCel.c.o" 		âˆ‚
+					"{ObjectDir}CrossFadeCels.c.o"			âˆ‚
+					"{ObjectDir}DeleteCelMagic.c.o" 		âˆ‚
+					"{ObjectDir}GetCelBufferSize.c.o"		âˆ‚
+					"{ObjectDir}InitCel.c.o"				âˆ‚
+					"{ObjectDir}InterUnionRect.c.o"			âˆ‚
+					"{ObjectDir}LinkCel.c.o"				âˆ‚
+					"{ObjectDir}LoadCel.c.o" 				âˆ‚
+					"{ObjectDir}MapCelToPoint.c.o"			âˆ‚
+					"{ObjectDir}MapCelToRect.c.o" 			âˆ‚
+					"{ObjectDir}MapCelToQuad.c.o" 			âˆ‚
+					"{ObjectDir}OffsetInsetRect.c.o"		âˆ‚
+					"{ObjectDir}OffsetCel.c.o"	 			âˆ‚
+					"{ObjectDir}ParseCel.c.o" 				âˆ‚
+					"{ObjectDir}PointConversions.c.o"		âˆ‚
+					"{ObjectDir}RectConversions.c.o" 		âˆ‚
+					"{ObjectDir}RectFromCel.c.o"			âˆ‚
+					"{ObjectDir}RenderCelPixel.c.o"			âˆ‚
+
+
+DisplayUtils =		âˆ‚
+					"{ObjectDir}ClearBitmap.c.o"			âˆ‚
+					"{ObjectDir}DrawImage.c.o"				âˆ‚
+					"{ObjectDir}LoadImage.c.o"				âˆ‚
+					"{ObjectDir}FadeFromBlack.c.o"			âˆ‚
+					"{ObjectDir}FadeToBlack.c.o"			âˆ‚
+					"{ObjectDir}CreateBasicDisplay.c.o"			âˆ‚
+
+
+IOUtils =			âˆ‚
+					"{ObjectDir}AsyncLoadFile.c.o"			âˆ‚
+					"{ObjectDir}BlockFile.c.o"				âˆ‚
+					"{ObjectDir}GetFileSize.c.o"			âˆ‚
+					"{ObjectDir}LoadFile.c.o"				âˆ‚
+					"{ObjectDir}ReadFile.c.o"				âˆ‚
+					"{ObjectDir}SaveFile.c.o"				âˆ‚
+					"{ObjectDir}WriteMacFile.c.o"			âˆ‚
+
+
+MiscUtils =			âˆ‚
+					"{ObjectDir}Debug3DO.c.o"				âˆ‚
+					"{ObjectDir}GetChunk.c.o"				âˆ‚
+					"{ObjectDir}UMemory.c.o"				âˆ‚
+					"{ObjectDir}MSEvents.c.o"				âˆ‚
+
+
+TimerUtils =			âˆ‚
+					"{ObjectDir}TimerServicesAPI.c.o"		âˆ‚
+					"{ObjectDir}TimerServicesAPIU.c.o"		âˆ‚
+					"{ObjectDir}TimerServicesAPIV.c.o"		âˆ‚
+					"{ObjectDir}TimerServicesThread.c.o"	âˆ‚
+					"{ObjectDir}TimerUtilsGetIOReq.c.o"		âˆ‚
+					"{ObjectDir}TimerUtilsGetTime.c.o"		âˆ‚
+					"{ObjectDir}TimerUtilsSleep.c.o"		âˆ‚
+
+
+TextLib =			âˆ‚
+					"{ObjectDir}taTextLib.c.o"				âˆ‚
+					"{ObjectDir}FontBlit3To8_.s.o"			âˆ‚
+					"{ObjectDir}FontBlit5To8_.s.o"			âˆ‚
+					"{ObjectDir}FontLib.c.o"				âˆ‚
+					"{ObjectDir}TextLib.c.o"				âˆ‚
+
+
+OBJECTS			=	âˆ‚
+					{AnimUtils}								âˆ‚
+					{CelUtils}								âˆ‚
+					{DisplayUtils}							âˆ‚
+					{IOUtils}								âˆ‚
+					{MiscUtils}								âˆ‚
+					{TimerUtils}							âˆ‚
+					{TextLib}								âˆ‚
+
+
+#####################################
+#	Default build rules
+#####################################
+
+CC				=	armcc
+ASM				=	armasm
+LIBRARIAN		=	armlib
+
+.c.o			Æ’	.c
+	{CC}  {DepDir}{Default}.c {COptions} -o {TargDir}{Default}.c.o
+
+.s.o			Æ’	.s
+	{ASM} {DepDir}{Default}.s {SOptions} -o {TargDir}{Default}.s.o
+
+#####################################
+#	Primary target build rules
+#####################################
+
+"{Library}"		Æ’ {OBJECTS}
+	{LIBRARIAN}	{LOptions} "{Library}" {OBJECTS}
+	SetVersion  "{Library}" -t 'vers' -version {Version}
+	Duplicate -y "{Library}" "{3DOLibs}{Library}"

--- a/release/examples/Miscellaneous/Compression/compression.make
+++ b/release/examples/Miscellaneous/Compression/compression.make
@@ -1,1 +1,82 @@
-######################################### Copyright (C) 1995, an unpublished work by The 3DO Company. All rights reserved.## This material contains confidential information that is the property of The 3DO Company.## Any unauthorized duplication, disclosure or use is prohibited.## $Id: compression.make,v 1.5 1995/01/19 02:40:34 mattm Exp $########################################   File:       compressexample.make#   Target:     compressexample#   Sources:    compressexample.c##   Copyright (c) 1995, The 3DO Company#   All rights reserved.#######################################	Symbol definitions#####################################App				= compressionDebugFlag		= 1SourceDir		= {3DOFolder}Examples:Miscellaneous:Compression:ObjectDir		= :Objects:ExecutableDir	= {SourceDir}Apps_Data:CC				= armccLINK			= armlinkTempDir			= :WorkingDisk		=######################################	Default compiler options#####################################COptions			= -fa -zps0 -za1CDebugOptions		= -g -d DEBUG={DebugFlag}LOptions			= -aif -r -b 0x00LStackSize			= 4096LDebugOptions		= -dModbinDebugOptions	= -debug######################################	Object files#####################################OBJECTS			=	 {ObjectDir}compression.c.o "{3DOLibs}"cstartup.oLIBS			=	 ¶					"{3DOLibs}compression.lib" ¶					"{3DOLibs}filesystem.lib" ¶					"{3DOLibs}clib.lib"######################################	Default build rules#####################################All				Ä	{App}{ObjectDir}		Ä	:.c.o	Ä	.c	{CC} -i "{3DOIncludes}" {COptions} {CDebugOptions} -o {TargDir}{Default}.c.o {DepDir}{Default}.c######################################	Target build rules#####################################{App} Ä {App}.make {OBJECTS}	{LINK} {LOptions} ¶		{OBJECTS} ¶		{LIBS} ¶		-o "{WorkingDisk}"{Targ}.nostrip	SetFile "{WorkingDisk}"{Targ}.nostrip -c 'EaDJ' -t 'PROJ'	modbin "{WorkingDisk}"{Targ}.nostrip -stack {LStackSize} {ModbinDebugOptions}	stripaif "{WorkingDisk}"{Targ}.nostrip -o {ExecutableDir}{Targ} -s {ExecutableDir}{Targ}.sym	delete "{WorkingDisk}"{Targ}.nostrip######################################	Additional Target Dependencies#####################################{ObjectDir}compression.c.o			Ä	{App}.make
+#####################################
+##
+## Copyright (C) 1995, an unpublished work by The 3DO Company. All rights reserved.
+## This material contains confidential information that is the property of The 3DO Company.
+## Any unauthorized duplication, disclosure or use is prohibited.
+## $Id: compression.make,v 1.5 1995/01/19 02:40:34 mattm Exp $
+##
+#####################################
+#   File:       compressexample.make
+#   Target:     compressexample
+#   Sources:    compressexample.c
+#
+#   Copyright (c) 1995, The 3DO Company
+#   All rights reserved.
+#
+
+#####################################
+#	Symbol definitions
+#####################################
+
+App				= compression
+DebugFlag		= 1
+SourceDir		= {3DOFolder}Examples:Miscellaneous:Compression:
+ObjectDir		= :Objects:
+ExecutableDir	= {SourceDir}Apps_Data:
+CC				= armcc
+LINK			= armlink
+TempDir			= :
+WorkingDisk		=
+
+#####################################
+#	Default compiler options
+#####################################
+
+COptions			= -fa -zps0 -za1
+CDebugOptions		= -g -d DEBUG={DebugFlag}
+LOptions			= -aif -r -b 0x00
+LStackSize			= 4096
+LDebugOptions		= -d
+ModbinDebugOptions	= -debug
+
+#####################################
+#	Object files
+#####################################
+
+OBJECTS			=	 {ObjectDir}compression.c.o "{3DOLibs}"cstartup.o
+
+LIBS			=	 âˆ‚
+					"{3DOLibs}compression.lib" âˆ‚
+					"{3DOLibs}filesystem.lib" âˆ‚
+					"{3DOLibs}clib.lib"
+
+#####################################
+#	Default build rules
+#####################################
+
+All				Æ’	{App}
+
+{ObjectDir}		Æ’	:
+
+.c.o	Æ’	.c
+	{CC} -i "{3DOIncludes}" {COptions} {CDebugOptions} -o {TargDir}{Default}.c.o {DepDir}{Default}.c
+
+#####################################
+#	Target build rules
+#####################################
+
+{App} Æ’ {App}.make {OBJECTS}
+	{LINK} {LOptions} âˆ‚
+		{OBJECTS} âˆ‚
+		{LIBS} âˆ‚
+		-o "{WorkingDisk}"{Targ}.nostrip
+	SetFile "{WorkingDisk}"{Targ}.nostrip -c 'EaDJ' -t 'PROJ'
+	modbin "{WorkingDisk}"{Targ}.nostrip -stack {LStackSize} {ModbinDebugOptions}
+	stripaif "{WorkingDisk}"{Targ}.nostrip -o {ExecutableDir}{Targ} -s {ExecutableDir}{Targ}.sym
+	delete "{WorkingDisk}"{Targ}.nostrip
+
+#####################################
+#	Additional Target Dependencies
+#####################################
+
+{ObjectDir}compression.c.o			Æ’	{App}.make

--- a/release/examples/Miscellaneous/Menu/menu.make
+++ b/release/examples/Miscellaneous/Menu/menu.make
@@ -1,1 +1,88 @@
-######################################### Copyright (C) 1995, an unpublished work by The 3DO Company. All rights reserved.## This material contains confidential information that is the property of The 3DO Company.## Any unauthorized duplication, disclosure or use is prohibited.## $Id: menu.make,v 1.7 1995/01/19 02:47:23 mattm Exp $########################################   File:       menu.make#   Target:     menu#   Sources:    menu.c##   Copyright (c) 1995, The 3DO Company#   All rights reserved.#######################################	Symbol definitions#####################################App				= menuDebugFlag		= 1SourceDir		= {3DOFolder}Examples:Miscellaneous:Menu:ObjectDir		= :Objects:ExecutableDir	= {SourceDir}Apps_Data:CC				= armccLINK			= armlinkWorkingDisk		=TempDir			= :######################################	Default compiler options#####################################COptions			= -fa -zps0 -za1CDebugOptions		= -g -d DEBUG={DebugFlag}LOptions			= -aif -r -b 0x00LStackSize			= 4096LDebugOptions		= -dModbinDebugOptions	= -debug######################################	Object files#####################################OBJECTS			=	 {ObjectDir}menu.c.o 		¶					 {ObjectDir}gfxutils.c.o	¶					 {ObjectDir}programlist.c.o	¶					 "{3DOLibs}"cstartup.oLIBS			=	 ¶					"{3DOLibs}filesystem.lib" ¶					"{3DOLibs}graphics.lib" ¶					"{3DOLibs}input.lib" ¶					"{3DOLibs}clib.lib"######################################	Default build rules#####################################All				Ä	{App}{ObjectDir}		Ä	:.c.o	Ä	.c	{CC} -i "{3DOIncludes}" {COptions} {CDebugOptions} -o {TargDir}{Default}.c.o {DepDir}{Default}.c######################################	Target build rules#####################################{App} Ä {App}.make {OBJECTS}	{LINK} {LOptions} ¶		{OBJECTS} ¶		{LIBS} ¶		-o "{WorkingDisk}"{Targ}.nostrip	SetFile "{WorkingDisk}"{Targ}.nostrip -c 'EaDJ' -t 'PROJ'	modbin "{WorkingDisk}"{Targ}.nostrip -stack {LStackSize} {ModbinDebugOptions}	stripaif "{WorkingDisk}"{Targ}.nostrip -o {ExecutableDir}{Targ} -s {ExecutableDir}{Targ}.sym	delete "{WorkingDisk}"{Targ}.nostrip######################################	Additional Target Dependencies#####################################{ObjectDir}menu.c.o			Ä	{App}.make{ObjectDir}gfxutils.c.o		Ä	{App}.make{ObjectDir}programlist.c.o	Ä	{App}.make
+#####################################
+##
+## Copyright (C) 1995, an unpublished work by The 3DO Company. All rights reserved.
+## This material contains confidential information that is the property of The 3DO Company.
+## Any unauthorized duplication, disclosure or use is prohibited.
+## $Id: menu.make,v 1.7 1995/01/19 02:47:23 mattm Exp $
+##
+#####################################
+#   File:       menu.make
+#   Target:     menu
+#   Sources:    menu.c
+#
+#   Copyright (c) 1995, The 3DO Company
+#   All rights reserved.
+#
+
+#####################################
+#	Symbol definitions
+#####################################
+
+App				= menu
+DebugFlag		= 1
+SourceDir		= {3DOFolder}Examples:Miscellaneous:Menu:
+ObjectDir		= :Objects:
+ExecutableDir	= {SourceDir}Apps_Data:
+CC				= armcc
+LINK			= armlink
+WorkingDisk		=
+TempDir			= :
+
+#####################################
+#	Default compiler options
+#####################################
+
+COptions			= -fa -zps0 -za1
+CDebugOptions		= -g -d DEBUG={DebugFlag}
+LOptions			= -aif -r -b 0x00
+LStackSize			= 4096
+LDebugOptions		= -d
+ModbinDebugOptions	= -debug
+
+#####################################
+#	Object files
+#####################################
+
+OBJECTS			=	 {ObjectDir}menu.c.o 		âˆ‚
+					 {ObjectDir}gfxutils.c.o	âˆ‚
+					 {ObjectDir}programlist.c.o	âˆ‚
+					 "{3DOLibs}"cstartup.o
+
+LIBS			=	 âˆ‚
+					"{3DOLibs}filesystem.lib" âˆ‚
+					"{3DOLibs}graphics.lib" âˆ‚
+					"{3DOLibs}input.lib" âˆ‚
+					"{3DOLibs}clib.lib"
+
+#####################################
+#	Default build rules
+#####################################
+
+All				Æ’	{App}
+
+{ObjectDir}		Æ’	:
+
+.c.o	Æ’	.c
+	{CC} -i "{3DOIncludes}" {COptions} {CDebugOptions} -o {TargDir}{Default}.c.o {DepDir}{Default}.c
+
+#####################################
+#	Target build rules
+#####################################
+
+{App} Æ’ {App}.make {OBJECTS}
+	{LINK} {LOptions} âˆ‚
+		{OBJECTS} âˆ‚
+		{LIBS} âˆ‚
+		-o "{WorkingDisk}"{Targ}.nostrip
+	SetFile "{WorkingDisk}"{Targ}.nostrip -c 'EaDJ' -t 'PROJ'
+	modbin "{WorkingDisk}"{Targ}.nostrip -stack {LStackSize} {ModbinDebugOptions}
+	stripaif "{WorkingDisk}"{Targ}.nostrip -o {ExecutableDir}{Targ} -s {ExecutableDir}{Targ}.sym
+	delete "{WorkingDisk}"{Targ}.nostrip
+
+#####################################
+#	Additional Target Dependencies
+#####################################
+
+{ObjectDir}menu.c.o			Æ’	{App}.make
+{ObjectDir}gfxutils.c.o		Æ’	{App}.make
+{ObjectDir}programlist.c.o	Æ’	{App}.make

--- a/release/examples/NVRAM/Access/access.make
+++ b/release/examples/NVRAM/Access/access.make
@@ -1,1 +1,81 @@
-######################################### Copyright (C) 1995, an unpublished work by The 3DO Company. All rights reserved.## This material contains confidential information that is the property of The 3DO Company.## Any unauthorized duplication, disclosure or use is prohibited.## $Id: access.make,v 1.3 1995/01/19 02:53:08 mattm Exp $########################################   File:       access.make#   Target:     access#   Sources:    access.c##   Copyright (c) 1995, The 3DO Company#   All rights reserved.#######################################	Symbol definitions#####################################App				= accessDebugFlag		= 1SourceDir		= {3DOFolder}Examples:NVRAM:Access:ObjectDir		= :Objects:Apps_Data		= :Apps_Data:CC				= armccLINK			= armlinkWorkingDisk		=3DOAutoDup		= -y######################################	Default compiler options#####################################COptions			= -fa -zps0 -za1CDebugOptions		= -g -d DEBUG={DebugFlag}LOptions			= -aif -r -b 0x00LStackSize			= 4096LDebugOptions		= -dModbinDebugOptions	= -debug######################################	Object files#####################################OBJECTS			=	 {ObjectDir}access.c.o "{3DOLibs}"cstartup.oLIBS			=	 ¶					"{3DOLibs}graphics.lib" "{3DOLibs}clib.lib" ¶######################################	Default build rules#####################################All				Ä	{App}{ObjectDir}		Ä	:.c.o	Ä	.c	{CC} -i "{3DOIncludes}" {COptions} {CDebugOptions} -o {TargDir}{Default}.c.o {DepDir}{Default}.c######################################	Target build rules#####################################{App} Ä {App}.make {OBJECTS}	{LINK} {LOptions} {LDebugOptions} ¶		{OBJECTS} ¶		{LIBS} ¶		-o "{WorkingDisk}"{Targ}	SetFile "{WorkingDisk}"{Targ} -c 'EaDJ' -t 'PROJ'	modbin "{WorkingDisk}"{Targ} -stack {LStackSize} {ModbinDebugOptions}	stripaif "{WorkingDisk}"{Targ} -o {Targ} -s {Targ}.sym	move {3DOAutodup} {Targ} "{Apps_Data}"	move {3DOAutodup} {Targ}.sym "{Apps_Data}"######################################	Additional Target Dependencies#####################################{ObjectDir}access.c.o			Ä	{App}.make
+#####################################
+##
+## Copyright (C) 1995, an unpublished work by The 3DO Company. All rights reserved.
+## This material contains confidential information that is the property of The 3DO Company.
+## Any unauthorized duplication, disclosure or use is prohibited.
+## $Id: access.make,v 1.3 1995/01/19 02:53:08 mattm Exp $
+##
+#####################################
+#   File:       access.make
+#   Target:     access
+#   Sources:    access.c
+#
+#   Copyright (c) 1995, The 3DO Company
+#   All rights reserved.
+#
+
+#####################################
+#	Symbol definitions
+#####################################
+
+App				= access
+DebugFlag		= 1
+SourceDir		= {3DOFolder}Examples:NVRAM:Access:
+ObjectDir		= :Objects:
+Apps_Data		= :Apps_Data:
+CC				= armcc
+LINK			= armlink
+WorkingDisk		=
+3DOAutoDup		= -y
+
+#####################################
+#	Default compiler options
+#####################################
+
+COptions			= -fa -zps0 -za1
+CDebugOptions		= -g -d DEBUG={DebugFlag}
+LOptions			= -aif -r -b 0x00
+LStackSize			= 4096
+LDebugOptions		= -d
+ModbinDebugOptions	= -debug
+
+#####################################
+#	Object files
+#####################################
+
+OBJECTS			=	 {ObjectDir}access.c.o "{3DOLibs}"cstartup.o
+
+LIBS			=	 âˆ‚
+					"{3DOLibs}graphics.lib" "{3DOLibs}clib.lib" âˆ‚
+
+#####################################
+#	Default build rules
+#####################################
+
+All				Æ’	{App}
+
+{ObjectDir}		Æ’	:
+
+.c.o	Æ’	.c
+	{CC} -i "{3DOIncludes}" {COptions} {CDebugOptions} -o {TargDir}{Default}.c.o {DepDir}{Default}.c
+
+#####################################
+#	Target build rules
+#####################################
+
+{App} Æ’ {App}.make {OBJECTS}
+	{LINK} {LOptions} {LDebugOptions} âˆ‚
+		{OBJECTS} âˆ‚
+		{LIBS} âˆ‚
+		-o "{WorkingDisk}"{Targ}
+	SetFile "{WorkingDisk}"{Targ} -c 'EaDJ' -t 'PROJ'
+	modbin "{WorkingDisk}"{Targ} -stack {LStackSize} {ModbinDebugOptions}
+	stripaif "{WorkingDisk}"{Targ} -o {Targ} -s {Targ}.sym
+	move {3DOAutodup} {Targ} "{Apps_Data}"
+	move {3DOAutodup} {Targ}.sym "{Apps_Data}"
+
+#####################################
+#	Additional Target Dependencies
+#####################################
+
+{ObjectDir}access.c.o			Æ’	{App}.make

--- a/release/examples/NVRAM/File_Management/nvram.make
+++ b/release/examples/NVRAM/File_Management/nvram.make
@@ -1,1 +1,81 @@
-######################################### Copyright (C) 1995, an unpublished work by The 3DO Company. All rights reserved.## This material contains confidential information that is the property of The 3DO Company.## Any unauthorized duplication, disclosure or use is prohibited.## $Id: nvram.make,v 1.3 1995/01/19 02:57:31 mattm Exp $########################################   File:       nvram.make#   Target:     nvram#   Sources:    nvram.c##   Copyright (c) 1995, The 3DO Company#   All rights reserved.#######################################	Symbol definitions#####################################App				= nvramDebugFlag		= 1SourceDir		= {3DOFolder}Examples:NVRAM:File_Management:ObjectDir		= :Objects:Apps_Data		= :Apps_Data:CC				= armccLINK			= armlinkWorkingDisk		=3DOAutodup		= -y######################################	Default compiler options#####################################COptions			= -fa -zps0 -za1CDebugOptions		= -g -d DEBUG={DebugFlag}LOptions			= -aif -r -b 0x00nvramtackSize		= 4096LDebugOptions		= -dModbinDebugOptions	= -debug######################################	Object files#####################################OBJECTS			=	 {ObjectDir}nvram.c.o "{3DOLibs}"cstartup.oLIBS			=	 ¶					"{3DOLibs}clib.lib" ¶######################################	Default build rules#####################################All				Ä	{App}{ObjectDir}		Ä	:.c.o	Ä	.c	{CC} -i "{3DOIncludes}" {COptions} {CDebugOptions} -o {TargDir}{Default}.c.o {DepDir}{Default}.c######################################	Target build rules#####################################{App} Ä {App}.make {OBJECTS}	{LINK} {LOptions} {LDebugOptions} ¶		{OBJECTS} ¶		{LIBS} ¶		-o "{WorkingDisk}"{Targ}	SetFile "{WorkingDisk}"{Targ} -c 'EaDJ' -t 'PROJ'	modbin "{WorkingDisk}"{Targ} -stack {nvramtackSize} {ModbinDebugOptions}	stripaif "{WorkingDisk}"{Targ} -o {Targ} -s {Targ}.sym	move {3DOAutodup} {Targ} "{Apps_Data}"	move {3DOAutodup} {Targ}.sym "{Apps_Data}"######################################	Additional Target Dependencies#####################################{ObjectDir}nvram.c.o			Ä	{App}.make
+#####################################
+##
+## Copyright (C) 1995, an unpublished work by The 3DO Company. All rights reserved.
+## This material contains confidential information that is the property of The 3DO Company.
+## Any unauthorized duplication, disclosure or use is prohibited.
+## $Id: nvram.make,v 1.3 1995/01/19 02:57:31 mattm Exp $
+##
+#####################################
+#   File:       nvram.make
+#   Target:     nvram
+#   Sources:    nvram.c
+#
+#   Copyright (c) 1995, The 3DO Company
+#   All rights reserved.
+#
+
+#####################################
+#	Symbol definitions
+#####################################
+
+App				= nvram
+DebugFlag		= 1
+SourceDir		= {3DOFolder}Examples:NVRAM:File_Management:
+ObjectDir		= :Objects:
+Apps_Data		= :Apps_Data:
+CC				= armcc
+LINK			= armlink
+WorkingDisk		=
+3DOAutodup		= -y
+
+#####################################
+#	Default compiler options
+#####################################
+
+COptions			= -fa -zps0 -za1
+CDebugOptions		= -g -d DEBUG={DebugFlag}
+LOptions			= -aif -r -b 0x00
+nvramtackSize		= 4096
+LDebugOptions		= -d
+ModbinDebugOptions	= -debug
+
+#####################################
+#	Object files
+#####################################
+
+OBJECTS			=	 {ObjectDir}nvram.c.o "{3DOLibs}"cstartup.o
+
+LIBS			=	 âˆ‚
+					"{3DOLibs}clib.lib" âˆ‚
+
+#####################################
+#	Default build rules
+#####################################
+
+All				Æ’	{App}
+
+{ObjectDir}		Æ’	:
+
+.c.o	Æ’	.c
+	{CC} -i "{3DOIncludes}" {COptions} {CDebugOptions} -o {TargDir}{Default}.c.o {DepDir}{Default}.c
+
+#####################################
+#	Target build rules
+#####################################
+
+{App} Æ’ {App}.make {OBJECTS}
+	{LINK} {LOptions} {LDebugOptions} âˆ‚
+		{OBJECTS} âˆ‚
+		{LIBS} âˆ‚
+		-o "{WorkingDisk}"{Targ}
+	SetFile "{WorkingDisk}"{Targ} -c 'EaDJ' -t 'PROJ'
+	modbin "{WorkingDisk}"{Targ} -stack {nvramtackSize} {ModbinDebugOptions}
+	stripaif "{WorkingDisk}"{Targ} -o {Targ} -s {Targ}.sym
+	move {3DOAutodup} {Targ} "{Apps_Data}"
+	move {3DOAutodup} {Targ}.sym "{Apps_Data}"
+
+#####################################
+#	Additional Target Dependencies
+#####################################
+
+{ObjectDir}nvram.c.o			Æ’	{App}.make

--- a/release/examples/NVRAM/Storage_Tuner/storagetuner.make
+++ b/release/examples/NVRAM/Storage_Tuner/storagetuner.make
@@ -1,1 +1,91 @@
-######################################### Copyright (C) 1995, an unpublished work by The 3DO Company. All rights reserved.## This material contains confidential information that is the property of The 3DO Company.## Any unauthorized duplication, disclosure or use is prohibited.## $Id: storagetuner.make,v 1.3 1995/01/19 03:04:23 mattm Exp $########################################   File:       storagetuner.make#   Target:     storagetuner#   Sources:    st.c stlists.c stmem.c##   Copyright 3DO Company, 1995#   All rights reserved.#######################################	Symbol definitions#####################################App				= storagetunerDebugFlag		= 1SourceDir		= {3DOFolder}Examples:NVRAM:Storage_Tuner:ObjectDir		= :Objects:Apps_Data		= :Apps_Data:CC				= armccLINK			= armlinkWorkingDisk		=3DOAutodup		= -y######################################	Default compiler options#####################################COptions			= -fa -zps0 -za1CDebugOptions		= -g -d DEBUG={DebugFlag}LOptions			= -aif -r -b 0x00LStackSize			= 4096LDebugOptions		= -dModbinDebugOptions	= -debug######################################	Object files#####################################OBJECTS			=	 {ObjectDir}st.c.o {ObjectDir}stlists.c.o {ObjectDir}stmem.c.o "{3DOLibs}"cstartup.oLIBS			=	 ¶					"{3DOLibs}Lib3DO.lib" ¶					"{3DOLibs}audio.lib" ¶					"{3DOLibs}music.lib" ¶					"{3DOLibs}operamath.lib" ¶					"{3DOLibs}filesystem.lib" ¶					"{3DOLibs}graphics.lib" ¶					"{3DOLibs}input.lib" ¶					"{3DOLibs}clib.lib"######################################	Default build rules#####################################All				Ä	{App}{ObjectDir}		Ä	:.c.o	Ä	.c	{CC} -i "{3DOIncludes}" {COptions} {CDebugOptions} -o {TargDir}{Default}.c.o {DepDir}{Default}.c######################################	Target build rules#####################################{App} Ä {App}.make {OBJECTS}	{LINK} {LOptions} {LDebugOptions} ¶		{OBJECTS} ¶		{LIBS} ¶		-o "{WorkingDisk}"{Targ}	SetFile "{WorkingDisk}"{Targ} -c 'EaDJ' -t PROJ	modbin "{WorkingDisk}"{Targ} -stack {LStackSize} {ModbinDebugOptions}	stripaif "{WorkingDisk}"{Targ} -o {Targ} -s {Targ}.sym	move {3DOAutodup} {Targ} "{Apps_Data}"	move {3DOAutodup} {Targ}.sym "{Apps_Data}"######################################	Additional Target Dependencies#####################################{ObjectDir}st.c.o			Ä	{App}.make{ObjectDir}stlists.c.o		Ä	{App}.make{ObjectDir}stmem.c.o		Ä	{App}.make
+#####################################
+##
+## Copyright (C) 1995, an unpublished work by The 3DO Company. All rights reserved.
+## This material contains confidential information that is the property of The 3DO Company.
+## Any unauthorized duplication, disclosure or use is prohibited.
+## $Id: storagetuner.make,v 1.3 1995/01/19 03:04:23 mattm Exp $
+##
+#####################################
+#   File:       storagetuner.make
+#   Target:     storagetuner
+#   Sources:    st.c stlists.c stmem.c
+#
+#   Copyright 3DO Company, 1995
+#   All rights reserved.
+#
+
+#####################################
+#	Symbol definitions
+#####################################
+
+App				= storagetuner
+DebugFlag		= 1
+SourceDir		= {3DOFolder}Examples:NVRAM:Storage_Tuner:
+ObjectDir		= :Objects:
+Apps_Data		= :Apps_Data:
+CC				= armcc
+LINK			= armlink
+WorkingDisk		=
+3DOAutodup		= -y
+
+#####################################
+#	Default compiler options
+#####################################
+
+COptions			= -fa -zps0 -za1
+CDebugOptions		= -g -d DEBUG={DebugFlag}
+LOptions			= -aif -r -b 0x00
+LStackSize			= 4096
+LDebugOptions		= -d
+ModbinDebugOptions	= -debug
+
+#####################################
+#	Object files
+#####################################
+
+OBJECTS			=	 {ObjectDir}st.c.o {ObjectDir}stlists.c.o {ObjectDir}stmem.c.o "{3DOLibs}"cstartup.o
+
+LIBS			=	 âˆ‚
+					"{3DOLibs}Lib3DO.lib" âˆ‚
+					"{3DOLibs}audio.lib" âˆ‚
+					"{3DOLibs}music.lib" âˆ‚
+					"{3DOLibs}operamath.lib" âˆ‚
+					"{3DOLibs}filesystem.lib" âˆ‚
+					"{3DOLibs}graphics.lib" âˆ‚
+					"{3DOLibs}input.lib" âˆ‚
+					"{3DOLibs}clib.lib"
+
+#####################################
+#	Default build rules
+#####################################
+
+All				Æ’	{App}
+
+{ObjectDir}		Æ’	:
+
+.c.o	Æ’	.c
+	{CC} -i "{3DOIncludes}" {COptions} {CDebugOptions} -o {TargDir}{Default}.c.o {DepDir}{Default}.c
+
+#####################################
+#	Target build rules
+#####################################
+
+{App} Æ’ {App}.make {OBJECTS}
+	{LINK} {LOptions} {LDebugOptions} âˆ‚
+		{OBJECTS} âˆ‚
+		{LIBS} âˆ‚
+		-o "{WorkingDisk}"{Targ}
+	SetFile "{WorkingDisk}"{Targ} -c 'EaDJ' -t PROJ
+	modbin "{WorkingDisk}"{Targ} -stack {LStackSize} {ModbinDebugOptions}
+	stripaif "{WorkingDisk}"{Targ} -o {Targ} -s {Targ}.sym
+	move {3DOAutodup} {Targ} "{Apps_Data}"
+	move {3DOAutodup} {Targ}.sym "{Apps_Data}"
+
+#####################################
+#	Additional Target Dependencies
+#####################################
+
+{ObjectDir}st.c.o			Æ’	{App}.make
+{ObjectDir}stlists.c.o		Æ’	{App}.make
+{ObjectDir}stmem.c.o		Æ’	{App}.make
+


### PR DESCRIPTION
Add some more details to README.md; reformat to make more readable in a
text editor.

Add .gitattributes to properly deal with newlines on multiple client
platforms.

The *.make files in the release/examples directories are "Makefiles"
intended for use with MPW (Macintosh Programmer's Workshop) on an Apple
Macintosh circa 1995.  This was an absolutely abominable perversion of
the then-standard Make syntax, and is all but meaningless today.  They
have been converted to UTF-8 encoding, and had their newlines converted
from old Mac format (\r) to standard (\n) so they're at least readable
on modern systems.